### PR TITLE
use mask for different consumers instead of dedicated variables

### DIFF
--- a/include/openearable_common.h
+++ b/include/openearable_common.h
@@ -92,9 +92,15 @@ struct sensor_data {
     uint8_t data[SENSOR_DATA_FIXED_LENGTH];
 } __attribute__((packed));
 
+enum sensor_consumer {
+	// only use numbers where single bits are set
+	// don't use 0x10
+	SENSOR_CONSUMER_BLE = 0x01,
+	SENSOR_CONSUMER_SD = 0x02,
+};
+
 struct sensor_msg {
-	bool sd;
-	bool stream;
+	uint8_t consumer_mask;
 	struct sensor_data data;
 };
 

--- a/src/ParseInfo/SensorScheme.h
+++ b/src/ParseInfo/SensorScheme.h
@@ -10,6 +10,7 @@ extern "C" {
 #include <zephyr/bluetooth/gatt.h>
 
 #include "SensorComponent.h"
+#include "openearable_common.h"
 
 #define BT_UUID_PARSE_INFO_SERVICE_VAL \
     BT_UUID_128_ENCODE(0xcaa25cb7, 0x7e1b, 0x44f2, 0xadc9, 0xe8c06c9ced43)
@@ -29,9 +30,9 @@ extern "C" {
 #define BT_UUID_PARSE_INFO_RESPONSE_CHARAC        BT_UUID_DECLARE_128(BT_UUID_PARSE_INFO_RESPONSE_CHARAC_VAL)
 
 enum SensorConfigOptionsMasks {
-    DATA_STREAMING = 0x01,
-    DATA_STORAGE = 0x02,
-    FREQUENCIES_DEFINED = 0x10,
+    DATA_STREAMING = SENSOR_CONSUMER_BLE,
+    DATA_STORAGE = SENSOR_CONSUMER_SD,
+    FREQUENCIES_DEFINED = 0x10, 
 };
 
 struct FrequencyOptions {

--- a/src/SD_Card/SDLogger/SDLogger.cpp
+++ b/src/SD_Card/SDLogger/SDLogger.cpp
@@ -57,7 +57,7 @@ void sensor_listener_cb(const struct zbus_channel *chan) {
     int ret;
     const sensor_msg* msg = (sensor_msg*)zbus_chan_const_msg(chan);
 
-	if (msg->sd) {
+	if (msg->consumer_mask & SENSOR_CONSUMER_SD) {
         /*if (!_prio_boost) {
             if (k_msgq_num_free_get(&sd_sensor_queue) < CONFIG_SENSOR_SD_SUB_QUEUE_SIZE / 2) {
                 k_thread_priority_set(thread_id, K_PRIO_PREEMPT(CONFIG_SENSOR_SD_THREAD_PRIO - 1));

--- a/src/SensorManager/Baro.cpp
+++ b/src/SensorManager/Baro.cpp
@@ -37,8 +37,7 @@ void Baro::update_sensor(struct k_work *work) {
 
 	bmp.performReading();
 
-	msg_baro.sd = sensor._sd_logging;
-	msg_baro.stream = sensor._ble_stream;
+	msg_baro.consumer_mask = sensor.consumers;
 
 	msg_baro.data.id = ID_TEMP_BARO;
 	msg_baro.data.size = 2 * sizeof(float);

--- a/src/SensorManager/BoneConduction.cpp
+++ b/src/SensorManager/BoneConduction.cpp
@@ -69,8 +69,7 @@ void BoneConduction::update_sensor(struct k_work *work) {
         int to_write = MIN(6, num_samples - written);
         if (to_write <= 0) break;
 
-        msg_bc.sd = sensor._sd_logging;
-        msg_bc.stream = sensor._ble_stream;
+        msg_bc.consumer_mask = sensor.consumers;
 
         const int _size = 3 * sizeof(int16_t);
 

--- a/src/SensorManager/EdgeMLSensor.h
+++ b/src/SensorManager/EdgeMLSensor.h
@@ -38,12 +38,16 @@ public:
         return _running;
     }
 
-    void sd_logging(bool enable) {
-        _sd_logging = enable;
-    }
+    // void add_consumer(uint8_t consumer) {
+    //     consumers |= consumer;
+    // }
 
-    void ble_stream(bool enable) {
-        _ble_stream = enable;
+    // void remove_consumer(uint8_t consumer) {
+    //     consumers &= ~consumer;
+    // }
+
+    void set_consumers(uint8_t consumer_mask) {
+        consumers = consumer_mask;
     }
 
     /**
@@ -59,8 +63,7 @@ protected:
     k_timer sensor_timer;
     static k_msgq * sensor_queue;
 
-    bool _sd_logging = false;
-    bool _ble_stream = true;
+    uint8_t consumers = 0;
     bool _running = false;
 };
 

--- a/src/SensorManager/IMU.cpp
+++ b/src/SensorManager/IMU.cpp
@@ -35,8 +35,7 @@ void IMU::update_sensor(struct k_work *work) {
 
 	size_t size =  3 * sizeof(float);
 	
-	msg_imu.sd = sensor._sd_logging;
-	msg_imu.stream = sensor._ble_stream;
+	msg_imu.consumer_mask = sensor.consumers;
 
 	msg_imu.data.id = ID_IMU;
 	msg_imu.data.size = 3 * size;

--- a/src/SensorManager/PPG.cpp
+++ b/src/SensorManager/PPG.cpp
@@ -91,8 +91,7 @@ void PPG::update_sensor(struct k_work *work) {
         PPG::sensor._sample_count = MAX(0, PPG::sensor._num_samples_buffered - num_samples);
 
         for (int i = 0; i < num_samples; i++) {
-            msg_ppg.sd = sensor._sd_logging;
-	        msg_ppg.stream = sensor._ble_stream;
+            msg_ppg.consumer_mask = sensor.consumers;
 
             size_t size = sizeof(uint32_t);
             

--- a/src/SensorManager/SensorManager.cpp
+++ b/src/SensorManager/SensorManager.cpp
@@ -202,8 +202,7 @@ static void config_work_handler(struct k_work *work) {
 		}
 	}
 
-	sensor->sd_logging(config.storageOptions & DATA_STORAGE);
-	sensor->ble_stream(config.storageOptions & DATA_STREAMING);
+	sensor->set_consumers(config.storageOptions);
 
 	if (config.storageOptions & (DATA_STORAGE | DATA_STREAMING)) {
 		if (sensor->init(&sensor_queue)) {

--- a/src/SensorManager/Temp.cpp
+++ b/src/SensorManager/Temp.cpp
@@ -59,8 +59,7 @@ void Temp::update_sensor(struct k_work *work) {
         return;
     }
 
-    msg_temp.sd = sensor._sd_logging;
-    msg_temp.stream = sensor._ble_stream;
+    msg_temp.consumer_mask = sensor.consumers;
 
     msg_temp.data.id = ID_OPTTEMP;
     msg_temp.data.size = sizeof(float);

--- a/src/audio/audio_datapath.c
+++ b/src/audio/audio_datapath.c
@@ -224,8 +224,7 @@ static void data_thread(void *arg1, void *arg2, void *arg3)
 			if (ret == 0 && logger_signaled != 0 && _record_to_sd) {
 				struct sensor_msg audio_msg;
 	
-				audio_msg.sd = true;
-				audio_msg.stream = false;
+				audio_msg.consumer_mask = SENSOR_CONSUMER_SD;
 	
 				audio_msg.data.id = ID_MICRO;
 				audio_msg.data.size = BLOCK_SIZE_BYTES; // SENQUEUE_FRAME_SIZE;

--- a/src/bluetooth/gatt_services/sensor_service.c
+++ b/src/bluetooth/gatt_services/sensor_service.c
@@ -241,7 +241,7 @@ void sensor_queue_listener_cb(const struct zbus_channel *chan) {
     
     msg = (struct sensor_msg *)zbus_chan_const_msg(&sensor_chan);
 
-	if (msg->stream) {
+	if (msg->consumer_mask & SENSOR_CONSUMER_BLE) {
 		ret = k_msgq_put(&gatt_queue, &msg->data, K_NO_WAIT);
 
 		if (ret) {


### PR DESCRIPTION
changed sd and ble attributes of EdgeMLSensor to a single mask attribute to enable future consumers