### PR TITLE
Make the microphone gain configurable

### DIFF
--- a/doc/dmic_gain_reference.rst
+++ b/doc/dmic_gain_reference.rst
@@ -1,0 +1,179 @@
+.. _dmic_gain_reference:
+
+DMIC Microphone Gain Control Reference
+#######################################
+
+.. contents::
+   :local:
+   :depth: 2
+
+Overview
+********
+
+The DMIC (Digital Microphone) gain on the ADAU1860 codec can now be adjusted over Bluetooth using the Audio Config Service characteristic ``BT_UUID_DMIC_GAIN`` (UUID: ``1410df99-5f68-4ebb-a7c7-5e0fb9ae7557``).
+
+Hardware Register Mapping
+**************************
+
+Based on ADAU186x datasheet (register DMIC_VOL0 @ address 0x4000C045):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 60
+
+   * - Register Value
+     - Gain (dB)
+     - Description
+   * - 0x00
+     - +24
+     - Maximum positive gain
+   * - 0x01
+     - +23.625
+     -
+   * - 0x02
+     - +23.25
+     -
+   * - ...
+     - ...
+     - Each step = -0.375 dB
+   * - 0x3F
+     - +0.375
+     -
+   * - **0x40**
+     - **0**
+     - **Reset/Default value**
+   * - 0x41
+     - -0.375
+     -
+   * - ...
+     - ...
+     - Each step = -0.375 dB
+   * - 0xFD
+     - -70.875
+     -
+   * - 0xFE
+     - -71.25
+     -
+   * - 0xFF
+     - ∞
+     - Mute (infinite attenuation)
+
+Gain Calculation
+*****************
+
+For any register value ``reg`` (0x00–0x3F for positive gains):
+
+- **Gain (dB) = 24 - (reg × 0.375)**
+
+For negative gains (0x41–0xFD):
+
+- **Gain (dB) = -(reg - 0x40) × 0.375**
+
+Examples
+========
+
+- ``0x00`` → 24 - (0 × 0.375) = **+24 dB**
+- ``0x10`` → 24 - (16 × 0.375) = **+18 dB**
+- ``0x20`` → 24 - (32 × 0.375) = **+12 dB** (initial value in this firmware)
+- ``0x40`` → **0 dB**
+- ``0x50`` → -(80 - 64) × 0.375 = **-6 dB**
+- ``0x60`` → -(96 - 64) × 0.375 = **-12 dB**
+
+BLE Protocol
+************
+
+Characteristic Details
+======================
+
+- **UUID**: ``0x1410df99-5f68-4ebb-a7c7-5e0fb9ae7557`` (under Audio Config Service)
+- **Properties**: Read, Write
+- **Payload**: 2 bytes
+
+Write Command
+=============
+
+Send 2 bytes ``[left_gain_reg, right_gain_reg]``:
+
+.. code-block:: text
+
+   Byte 0: Left DMIC channel gain register (0x00–0xFF)
+   Byte 1: Right DMIC channel gain register (0x00–0xFF)
+
+Read Response
+=============
+
+Returns 2 bytes showing current DMIC gain for each channel.
+
+Usage Examples
+**************
+
+Set both channels to +12 dB
+============================
+
+Send: ``[0x20, 0x20]``
+
+Set left to +18 dB, right to +6 dB
+===================================
+
+Send: ``[0x10, 0x30]``
+
+(0x10 = 24 - 16×0.375 = +18 dB, 0x30 = 24 - 48×0.375 = +6 dB)
+
+Set to 0 dB (neutral/reset)
+============================
+
+Send: ``[0x40, 0x40]``
+
+Mute both channels
+==================
+
+Send: ``[0xFF, 0xFF]``
+
+Set left to -12 dB (96 = 0x60)
+===============================
+
+Send: ``[0x60, 0x40]``
+
+API Reference (C/C++)
+*********************
+
+Functions
+=========
+
+.. code-block:: c
+
+   // Set DMIC gain for both channels
+   // gain_left_reg, gain_right_reg: register values (0x00–0xFF)
+   int hw_codec_mic_gain_set(uint8_t gain_left_reg, uint8_t gain_right_reg);
+
+   // Get current DMIC gain register value for left/right channel
+   uint8_t hw_codec_mic_gain_get_left(void);
+   uint8_t hw_codec_mic_gain_get_right(void);
+
+Example C Code
+==============
+
+.. code-block:: cpp
+
+   // Set left and right DMIC to +12 dB
+   hw_codec_mic_gain_set(0x20, 0x20);
+
+   // Read back the values
+   uint8_t left = hw_codec_mic_gain_get_left();   // Should return 0x20
+   uint8_t right = hw_codec_mic_gain_get_right();  // Should return 0x20
+
+Implementation Details
+**********************
+
+- **File**: ``src/modules/hw_codec_adau1860.cpp``
+- **Registers Written**: ``DMIC_VOL0`` (0x4000C045), ``DMIC_VOL1`` (0x4000C046)
+- **BLE Handler**: ``src/bluetooth/gatt_services/audio_config_service.c``
+- **Logging**: INFO level logs show when gain is changed via BLE
+
+Notes
+*****
+
+- Each register value change takes effect immediately on the hardware.
+- Default at startup: 0x20 (+12 dB) for both channels (set in ``ADAU1860::begin()``).
+- The characteristic is read/write; clients can query current gain and set new values.
+- The 0.375 dB step provides fine-grained control with 256 possible values.

--- a/src/bluetooth/gatt_services/audio_config_service.c
+++ b/src/bluetooth/gatt_services/audio_config_service.c
@@ -72,6 +72,45 @@ static ssize_t read_audio_channel(struct bt_conn *conn, const struct bt_gatt_att
     return bt_gatt_attr_read(conn, attr, buf, len, offset, &channel_u8, sizeof(channel));
 }
 
+static ssize_t write_dmic_gain(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+                             const void *buf, uint16_t len, uint16_t offset, uint8_t flags)
+{
+    // Mic gain is 2 bytes: [left_reg, right_reg].
+    // Per ADAU186x DMIC_VOL register (0x4000C045):
+    //   0x00      = +24 dB
+    //   0x01-0x3F = +23.625 to +0.375 dB (0.375 dB steps)
+    //   0x40      = 0 dB
+    //   0x41-0xFD = -0.375 to -70.875 dB (0.375 dB steps)
+    //   0xFE      = -71.25 dB
+    //   0xFF      = Mute
+    if (len != 2) {
+        return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+    }
+
+    uint8_t gain_left = ((uint8_t*)buf)[0];
+    uint8_t gain_right = ((uint8_t*)buf)[1];
+
+    int ret = hw_codec_mic_gain_set(gain_left, gain_right);
+    if (ret) {
+        LOG_ERR("Failed to set mic gain: %d", ret);
+        return BT_GATT_ERR(BT_ATT_ERR_VALUE_NOT_ALLOWED);
+    }
+
+    LOG_INF("DMIC gain via BLE: L=0x%02x R=0x%02x", gain_left, gain_right);
+    return len;
+}
+
+static ssize_t read_dmic_gain(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+                            void *buf, uint16_t len, uint16_t offset)
+{
+    uint8_t gains[2] = {
+        hw_codec_mic_gain_get_left(),
+        hw_codec_mic_gain_get_right()
+    };
+
+    return bt_gatt_attr_read(conn, attr, buf, len, offset, gains, sizeof(gains));
+}
+
 BT_GATT_SERVICE_DEFINE(audio_config_svc,
     BT_GATT_PRIMARY_SERVICE(BT_UUID_AUDIO_CONFIG_SERVICE),
     BT_GATT_CHARACTERISTIC(BT_UUID_AUDIO_MODE,
@@ -86,6 +125,10 @@ BT_GATT_SERVICE_DEFINE(audio_config_svc,
                        BT_GATT_CHRC_READ,
                        BT_GATT_PERM_READ,
                        read_audio_channel, NULL, NULL),
+    BT_GATT_CHARACTERISTIC(BT_UUID_DMIC_GAIN,
+                       BT_GATT_CHRC_WRITE | BT_GATT_CHRC_READ,
+                       BT_GATT_PERM_WRITE | BT_GATT_PERM_READ,
+                       read_dmic_gain, write_dmic_gain, NULL),
 );
 
 int init_audio_config_service(void)

--- a/src/bluetooth/gatt_services/audio_config_service.h
+++ b/src/bluetooth/gatt_services/audio_config_service.h
@@ -33,6 +33,13 @@
 #define BT_UUID_AUDIO_CHANNEL \
 	BT_UUID_DECLARE_128(BT_UUID_AUDIO_CHANNEL_VAL)
 
+// DMIC Gain Characteristic UUID
+#define BT_UUID_DMIC_GAIN_VAL \
+	BT_UUID_128_ENCODE(0x1410df99, 0x5f68, 0x4ebb, 0xa7c7, 0x5e0fb9ae7557)
+
+#define BT_UUID_DMIC_GAIN \
+	BT_UUID_DECLARE_128(BT_UUID_DMIC_GAIN_VAL)
+
 int init_audio_config_service(void);
 
 #endif /* _AUDIO_CONFIG_SERVICE_H_ */

--- a/src/drivers/ADAU1860.cpp
+++ b/src/drivers/ADAU1860.cpp
@@ -210,6 +210,8 @@ int ADAU1860::begin() {
 
                 // DMIC_VOL0
                 uint8_t dmic_vol = 0x20; // 12dB
+                // 0 - left - external mic
+                // 1 - right - internal mic
                 writeReg(registers::DMIC_VOL0, &dmic_vol, sizeof(dmic_vol));
                 writeReg(registers::DMIC_VOL1, &dmic_vol, sizeof(dmic_vol));
 
@@ -493,6 +495,18 @@ uint8_t ADAU1860::fdsp_get_volume() {
         uint8_t dac_vol = 0;
         readReg(registers::DAC_VOL0, &dac_vol, sizeof(dac_vol));
         return 0xFF-dac_vol;
+}
+
+void ADAU1860::mic_gain_write(uint8_t channel, uint8_t gain) {
+        uint32_t reg = (channel == 0) ? registers::DMIC_VOL0 : registers::DMIC_VOL1;
+        writeReg(reg, &gain, sizeof(gain));
+}
+
+uint8_t ADAU1860::mic_gain_read(uint8_t channel) {
+        uint8_t val = 0;
+        uint32_t reg = (channel == 0) ? registers::DMIC_VOL0 : registers::DMIC_VOL1;
+        readReg(reg, &val, sizeof(val));
+        return val;
 }
 
 int ADAU1860::soft_reset(bool full_reset) {

--- a/src/drivers/ADAU1860.h
+++ b/src/drivers/ADAU1860.h
@@ -412,6 +412,10 @@ public:
 
     uint8_t get_volume();
 
+    // DMIC gain control
+    void mic_gain_write(uint8_t channel, uint8_t gain);
+    uint8_t mic_gain_read(uint8_t channel);
+
 #if CONFIG_FDSP
     int fdsp_bank_select(uint8_t bank);
 #endif

--- a/src/modules/hw_codec.h
+++ b/src/modules/hw_codec.h
@@ -119,6 +119,20 @@ int hw_codec_set_audio_mode(enum audio_mode mode);
 
 enum audio_mode hw_codec_get_audio_mode();
 
+/* Microphone (DMIC) gain control (ADAU186x DMIC_VOL registers).
+ * Register mapping (per ADAU186x datasheet DMIC_VOL0 @ 0x4000C045):
+ *   0x00      = +24 dB
+ *   0x01-0x3F = +23.625 to +0.375 dB (decrement by 0.375 dB per step)
+ *   0x40      = 0 dB (reset value)
+ *   0x41-0xFD = -0.375 to -70.875 dB (decrement by 0.375 dB per step)
+ *   0xFE      = -71.25 dB
+ *   0xFF      = Mute
+ * Recommended BLE range: 0x00-0x40 for +24 dB to 0 dB.
+ */
+int hw_codec_mic_gain_set(uint8_t gain_left_reg, uint8_t gain_right_reg);
+uint8_t hw_codec_mic_gain_get_left(void);
+uint8_t hw_codec_mic_gain_get_right(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/modules/hw_codec_adau1860.cpp
+++ b/src/modules/hw_codec_adau1860.cpp
@@ -308,6 +308,34 @@ int hw_codec_stop_audio(void)
 	return 0;
 }
 
+/* Microphone (DMIC) gain control using ADAU186x DMIC_VOL0/1 registers.
+ * Per ADAU186x datasheet register DMIC_VOL0 (addr 0x4000C045):
+ *   0x00      = +24 dB
+ *   0x01-0x3F = +23.625 to +0.375 dB (decrement by 0.375 dB per step)
+ *   0x40      = 0 dB (reset value)
+ *   0x41-0xFD = -0.375 to -70.875 dB (decrement by 0.375 dB per step)
+ *   0xFE      = -71.25 dB
+ *   0xFF      = Mute
+ */
+int hw_codec_mic_gain_set(uint8_t gain_left_reg, uint8_t gain_right_reg)
+{
+	/* Write DMIC gain for channels 0 and 1 */
+	dac.mic_gain_write(0, gain_left_reg);
+	dac.mic_gain_write(1, gain_right_reg);
+	LOG_INF("DMIC gain set: L=0x%02x, R=0x%02x", gain_left_reg, gain_right_reg);
+	return 0;
+}
+
+uint8_t hw_codec_mic_gain_get_left(void)
+{
+	return dac.mic_gain_read(0);
+}
+
+uint8_t hw_codec_mic_gain_get_right(void)
+{
+	return dac.mic_gain_read(1);
+}
+
 int hw_codec_soft_reset(void)
 {
 	int ret;


### PR DESCRIPTION
## Summary
Add Bluetooth control for ADAU1860 digital microphone gain with 0.375 dB 
step resolution across +24 dB to mute range.

## Changes Made
- Add BT_UUID_DMIC_GAIN characteristic (0x1410df99)
- Add ADAU1860 driver methods for DMIC_VOL0/1 registers
- Implement hw_codec abstraction layer
- Add BLE read/write handlers
- Added RST documentation, this can be removed if not in the style of the repo
- Add comprehensive RST documentation

## To do
- Verify gain control via BLE on hardware
- Test left/right channel independence
- Confirm full range: +24 dB → 0 dB → -70 dB then mute/off
- Check for audio artifacts during gain transitions
- Check left/right match with external internal mics
- Update app to transmit gain characteristic.

## Notes
- Replaces deprecated PDM terminology with DMIC
- Default gain: +12 dB (0x20) for both channels, maybe reduce this to 0 dB as discussed
- Check whether it works with developing audio modes (Normal/Transparency/ANC)