### PR TITLE
fix(firmware): identify OpenEarable app core

### DIFF
--- a/src/utils/fw_info_app.c.in
+++ b/src/utils/fw_info_app.c.in
@@ -19,7 +19,7 @@ LOG_MODULE_REGISTER(fw_info, CONFIG_FW_INFO_LOG_LEVEL);
 
 static const char COMPILE_DATE[] = "@NRF5340_AUDIO_CORE_APP_COMP_DATE@";
 /* NOTE: The string below is used by the Nordic CI system */
-static const char NRF5340_CORE[] = "nRF5340 Audio nRF5340 Audio DK cpuapp";
+static const char NRF5340_CORE[] = "OpenEarable2 nRF5340 Audio DK cpuapp";
 
 int fw_info_app_print(void)
 {


### PR DESCRIPTION
Draft PR extracted from thandal/open-earable-2. Updates the firmware info string to identify the OpenEarable app core.