### PR TITLE
Fix 32 MHz SPI clock on OpenEarable v2

### DIFF
--- a/boards/teco/openearable_v2/board_init.c
+++ b/boards/teco/openearable_v2/board_init.c
@@ -3,6 +3,7 @@
 #include <zephyr/device.h>
 #include <zephyr/pm/device.h>  // ✅ Correct Power Management API
 #include <zephyr/logging/log.h>
+#include <nrfx_clock.h>
 LOG_MODULE_REGISTER(board_init, LOG_LEVEL_DBG);
 
 //#include "nrf5340_audio_common.h"
@@ -21,6 +22,22 @@ const struct device *const cons = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
 const struct device *const ls_1_8 = DEVICE_DT_GET(load_switch_1_8_id);
 const struct device *const ls_3_3 = DEVICE_DT_GET(load_switch_3_3_id);
 const struct device *const ls_sd = DEVICE_DT_GET(load_switch_sd_id);
+
+static int app_core_hfclk_divider_init(void)
+{
+    int ret = nrfx_clock_divider_set(NRF_CLOCK_DOMAIN_HFCLK, NRF_CLOCK_HFCLK_DIV_1);
+
+    ret -= NRFX_ERROR_BASE_NUM;
+    if (ret) {
+        LOG_WRN("Failed to set app core HFCLK divider to DIV_1: %d", ret);
+        return ret;
+    }
+
+    LOG_DBG("App core HFCLK divider set to DIV_1");
+
+    return 0;
+}
+SYS_INIT(app_core_hfclk_divider_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 
 struct load_switch_data {
     struct gpio_dt_spec ctrl_pin;


### PR DESCRIPTION
## Summary
- Set the nRF5340 application core HFCLK divider to DIV_1 during OpenEarable v2 board init.
- Run the divider setup before SPI device initialization so the Zephyr nRF SPIM driver can use the configured 32 MHz SPI clock.

## Verification
- Built FOTA sysbuild: cmake --build build_fota
- Hardware benchmark before fix: 32 MHz requested stayed at about 15.35 Mbit/s.
- Hardware benchmark after fix: 32 MHz requested reached about 30.60 Mbit/s with hfclk_div=0.

## Note
This keeps the application core at 128 MHz earlier in boot, which can increase power consumption versus the default 64 MHz divider.