### PR TITLE
Fix FOTA crash during image upload

### DIFF
--- a/src/bluetooth/bt_management/CMakeLists.txt
+++ b/src/bluetooth/bt_management/CMakeLists.txt
@@ -42,6 +42,8 @@ endif()
 
 if (CONFIG_AUDIO_BT_MGMT_DFU)
 	target_sources(app PRIVATE
+		${CMAKE_CURRENT_SOURCE_DIR}/dfu/bt_mgmt_dfu_activity.c
+		${CMAKE_CURRENT_SOURCE_DIR}/dfu/bt_mgmt_dfu_indicator.c
 		${CMAKE_CURRENT_SOURCE_DIR}/dfu/bt_mgmt_dfu.c
 		${CMAKE_CURRENT_SOURCE_DIR}/dfu/bt_mgmt_dfu_auto_off.c
 	)

--- a/src/bluetooth/bt_management/dfu/bt_mgmt_dfu.c
+++ b/src/bluetooth/bt_management/dfu/bt_mgmt_dfu.c
@@ -15,6 +15,7 @@
 #include "string.h"
 #include "macros_common.h"
 #include "channel_assignment.h"
+#include "StateIndicatorC.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_mgmt_dfu, CONFIG_BT_MGMT_DFU_LOG_LEVEL);
@@ -123,6 +124,7 @@ void bt_mgmt_dfu_start(void)
 
 	bt_conn_cb_register(&dfu_conn_callbacks);
 	dfu_set_bt_name();
+	state_indicator_set_dfu_active(true);
 
 	while (1) {
 		/* In DFU mode, the device should always advertise */

--- a/src/bluetooth/bt_management/dfu/bt_mgmt_dfu_activity.c
+++ b/src/bluetooth/bt_management/dfu/bt_mgmt_dfu_activity.c
@@ -1,0 +1,56 @@
+#include "bt_mgmt_dfu_activity.h"
+
+#include <zephyr/init.h>
+#include <zephyr/mgmt/mcumgr/mgmt/callbacks.h>
+#include <zephyr/mgmt/mcumgr/mgmt/mgmt.h>
+
+#include "bt_mgmt_dfu_auto_off.h"
+#include "bt_mgmt_dfu_indicator.h"
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(bt_mgmt_dfu_activity, CONFIG_BT_MGMT_DFU_LOG_LEVEL);
+
+#ifdef CONFIG_MCUMGR_MGMT_NOTIFICATION_HOOKS
+
+static struct mgmt_callback dfu_activity_mgmt_cb;
+
+void bt_mgmt_dfu_activity_chunk_received(void)
+{
+	bt_mgmt_dfu_auto_off_hold();
+	bt_mgmt_dfu_indicator_update_chunk_led();
+}
+
+static enum mgmt_cb_return dfu_activity_mgmt_callback(uint32_t event,
+						      enum mgmt_cb_return prev_status,
+						      int32_t *rc, uint16_t *group,
+						      bool *abort_more, void *data,
+						      size_t data_size)
+{
+	ARG_UNUSED(prev_status);
+	ARG_UNUSED(rc);
+	ARG_UNUSED(group);
+	ARG_UNUSED(abort_more);
+	ARG_UNUSED(data);
+	ARG_UNUSED(data_size);
+
+	if (event == MGMT_EVT_OP_IMG_MGMT_DFU_CHUNK) {
+		bt_mgmt_dfu_activity_chunk_received();
+	}
+
+	return MGMT_CB_OK;
+}
+
+#endif
+
+int bt_mgmt_dfu_activity_init(void)
+{
+#ifdef CONFIG_MCUMGR_MGMT_NOTIFICATION_HOOKS
+	dfu_activity_mgmt_cb.callback = dfu_activity_mgmt_callback;
+	dfu_activity_mgmt_cb.event_id = MGMT_EVT_OP_IMG_MGMT_DFU_CHUNK;
+	mgmt_callback_register(&dfu_activity_mgmt_cb);
+#endif
+
+	return 0;
+}
+
+SYS_INIT(bt_mgmt_dfu_activity_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);

--- a/src/bluetooth/bt_management/dfu/bt_mgmt_dfu_activity.h
+++ b/src/bluetooth/bt_management/dfu/bt_mgmt_dfu_activity.h
@@ -1,0 +1,8 @@
+#ifndef _BT_MGMT_DFU_ACTIVITY_H_
+#define _BT_MGMT_DFU_ACTIVITY_H_
+
+int bt_mgmt_dfu_activity_init(void);
+
+void bt_mgmt_dfu_activity_chunk_received(void);
+
+#endif /* _BT_MGMT_DFU_ACTIVITY_H_ */

--- a/src/bluetooth/bt_management/dfu/bt_mgmt_dfu_auto_off.c
+++ b/src/bluetooth/bt_management/dfu/bt_mgmt_dfu_auto_off.c
@@ -1,10 +1,9 @@
 #include "AutoOffManager.h"
+#include "bt_mgmt_dfu_auto_off.h"
 
 #include <errno.h>
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
-#include <zephyr/mgmt/mcumgr/mgmt/callbacks.h>
-#include <zephyr/mgmt/mcumgr/mgmt/mgmt.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_mgmt_dfu_auto_off, CONFIG_BT_MGMT_DFU_LOG_LEVEL);
@@ -19,8 +18,6 @@ LOG_MODULE_REGISTER(bt_mgmt_dfu_auto_off, CONFIG_BT_MGMT_DFU_LOG_LEVEL);
 static const char dfu_auto_off_token[] = "DFU";
 #define DFU_CHUNK_RECEIVED_LATCH_TIME K_MINUTES(5)
 
-static struct mgmt_callback dfu_auto_off_mgmt_cb;
-
 static void dfu_auto_off_release_work_handler(struct k_work *work);
 K_WORK_DELAYABLE_DEFINE(dfu_auto_off_release_work, dfu_auto_off_release_work_handler);
 
@@ -31,33 +28,13 @@ static void dfu_auto_off_release_work_handler(struct k_work *work)
 	auto_off_allow(dfu_auto_off_token);
 }
 
-static void dfu_auto_off_hold(void)
+void bt_mgmt_dfu_auto_off_hold(void)
 {
 	auto_off_prohibit(dfu_auto_off_token);
 	(void)k_work_reschedule(&dfu_auto_off_release_work, DFU_CHUNK_RECEIVED_LATCH_TIME);
 }
 
-static enum mgmt_cb_return dfu_auto_off_mgmt_callback(uint32_t event,
-						      enum mgmt_cb_return prev_status,
-						      int32_t *rc, uint16_t *group,
-						      bool *abort_more, void *data,
-						      size_t data_size)
-{
-	ARG_UNUSED(prev_status);
-	ARG_UNUSED(rc);
-	ARG_UNUSED(group);
-	ARG_UNUSED(abort_more);
-	ARG_UNUSED(data);
-	ARG_UNUSED(data_size);
-
-	if (event == MGMT_EVT_OP_IMG_MGMT_DFU_CHUNK) {
-		dfu_auto_off_hold();
-	}
-
-	return MGMT_CB_OK;
-}
-
-static int bt_mgmt_dfu_auto_off_init(void)
+int bt_mgmt_dfu_auto_off_init(void)
 {
 	int ret;
 
@@ -68,10 +45,6 @@ static int bt_mgmt_dfu_auto_off_init(void)
 	}
 
 	auto_off_allow(dfu_auto_off_token);
-
-	dfu_auto_off_mgmt_cb.callback = dfu_auto_off_mgmt_callback;
-	dfu_auto_off_mgmt_cb.event_id = MGMT_EVT_OP_IMG_MGMT_DFU_CHUNK;
-	mgmt_callback_register(&dfu_auto_off_mgmt_cb);
 
 	return 0;
 }

--- a/src/bluetooth/bt_management/dfu/bt_mgmt_dfu_auto_off.h
+++ b/src/bluetooth/bt_management/dfu/bt_mgmt_dfu_auto_off.h
@@ -1,0 +1,8 @@
+#ifndef _BT_MGMT_DFU_AUTO_OFF_H_
+#define _BT_MGMT_DFU_AUTO_OFF_H_
+
+int bt_mgmt_dfu_auto_off_init(void);
+
+void bt_mgmt_dfu_auto_off_hold(void);
+
+#endif /* _BT_MGMT_DFU_AUTO_OFF_H_ */

--- a/src/bluetooth/bt_management/dfu/bt_mgmt_dfu_indicator.c
+++ b/src/bluetooth/bt_management/dfu/bt_mgmt_dfu_indicator.c
@@ -1,4 +1,5 @@
 #include "bt_mgmt_dfu_indicator.h"
+#include "StateIndicatorC.h"
 
 #include <errno.h>
 #include <zephyr/drivers/gpio.h>
@@ -9,13 +10,17 @@
 LOG_MODULE_REGISTER(bt_mgmt_dfu_indicator, CONFIG_BT_MGMT_DFU_LOG_LEVEL);
 
 #define DFU_CHUNK_LED_PULSE_TIME K_MSEC(30)
+#define DFU_STATUS_LED_LATCH_TIME K_MSEC(2000)
 
 static const struct gpio_dt_spec dfu_activity_led =
 	GPIO_DT_SPEC_GET_OR(DT_NODELABEL(led_error), gpios, {0});
 static bool dfu_activity_led_ready;
+static bool dfu_status_indicator_active;
 
 static void dfu_activity_led_release_work_handler(struct k_work *work);
 K_WORK_DELAYABLE_DEFINE(dfu_activity_led_release_work, dfu_activity_led_release_work_handler);
+static void dfu_status_indicator_release_work_handler(struct k_work *work);
+K_WORK_DELAYABLE_DEFINE(dfu_status_indicator_release_work, dfu_status_indicator_release_work_handler);
 
 static void dfu_activity_led_release_work_handler(struct k_work *work)
 {
@@ -28,8 +33,23 @@ static void dfu_activity_led_release_work_handler(struct k_work *work)
 	(void)gpio_pin_set_dt(&dfu_activity_led, 0);
 }
 
+static void dfu_status_indicator_release_work_handler(struct k_work *work)
+{
+	ARG_UNUSED(work);
+
+	dfu_status_indicator_active = false;
+	state_indicator_set_dfu_active(false);
+}
+
 void bt_mgmt_dfu_indicator_update_chunk_led(void)
 {
+	if (!dfu_status_indicator_active) {
+		dfu_status_indicator_active = true;
+		state_indicator_set_dfu_active(true);
+	}
+
+	(void)k_work_reschedule(&dfu_status_indicator_release_work, DFU_STATUS_LED_LATCH_TIME);
+
 	if (!dfu_activity_led_ready) {
 		return;
 	}

--- a/src/bluetooth/bt_management/dfu/bt_mgmt_dfu_indicator.c
+++ b/src/bluetooth/bt_management/dfu/bt_mgmt_dfu_indicator.c
@@ -1,0 +1,72 @@
+#include "bt_mgmt_dfu_indicator.h"
+
+#include <errno.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(bt_mgmt_dfu_indicator, CONFIG_BT_MGMT_DFU_LOG_LEVEL);
+
+#define DFU_CHUNK_LED_PULSE_TIME K_MSEC(30)
+
+static const struct gpio_dt_spec dfu_activity_led =
+	GPIO_DT_SPEC_GET_OR(DT_NODELABEL(led_error), gpios, {0});
+static bool dfu_activity_led_ready;
+
+static void dfu_activity_led_release_work_handler(struct k_work *work);
+K_WORK_DELAYABLE_DEFINE(dfu_activity_led_release_work, dfu_activity_led_release_work_handler);
+
+static void dfu_activity_led_release_work_handler(struct k_work *work)
+{
+	ARG_UNUSED(work);
+
+	if (!dfu_activity_led_ready) {
+		return;
+	}
+
+	(void)gpio_pin_set_dt(&dfu_activity_led, 0);
+}
+
+void bt_mgmt_dfu_indicator_update_chunk_led(void)
+{
+	if (!dfu_activity_led_ready) {
+		return;
+	}
+
+	(void)gpio_pin_set_dt(&dfu_activity_led, 1);
+	(void)k_work_reschedule(&dfu_activity_led_release_work, DFU_CHUNK_LED_PULSE_TIME);
+}
+
+int bt_mgmt_dfu_indicator_init(void)
+{
+	int ret;
+
+	dfu_activity_led_ready = device_is_ready(dfu_activity_led.port);
+	if (!dfu_activity_led_ready) {
+		LOG_WRN("DFU activity LED not ready");
+		return -ENODEV;
+	}
+
+	ret = gpio_pin_configure_dt(&dfu_activity_led, GPIO_OUTPUT_INACTIVE);
+	if (ret) {
+		LOG_WRN("Failed to configure DFU activity LED: %d", ret);
+		dfu_activity_led_ready = false;
+		return ret;
+	}
+
+	return 0;
+}
+
+static int bt_mgmt_dfu_indicator_sys_init(void)
+{
+	int ret = bt_mgmt_dfu_indicator_init();
+
+	if (ret && ret != -ENODEV) {
+		return ret;
+	}
+
+	return 0;
+}
+
+SYS_INIT(bt_mgmt_dfu_indicator_sys_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);

--- a/src/bluetooth/bt_management/dfu/bt_mgmt_dfu_indicator.h
+++ b/src/bluetooth/bt_management/dfu/bt_mgmt_dfu_indicator.h
@@ -1,0 +1,8 @@
+#ifndef _BT_MGMT_DFU_INDICATOR_H_
+#define _BT_MGMT_DFU_INDICATOR_H_
+
+int bt_mgmt_dfu_indicator_init(void);
+
+void bt_mgmt_dfu_indicator_update_chunk_led(void);
+
+#endif /* _BT_MGMT_DFU_INDICATOR_H_ */

--- a/src/utils/StateIndicator.cpp
+++ b/src/utils/StateIndicator.cpp
@@ -9,45 +9,11 @@
 
 #include "channel_assignment.h"
 
-#ifdef CONFIG_MCUMGR_MGMT_NOTIFICATION_HOOKS
-#include <zephyr/mgmt/mcumgr/mgmt/mgmt.h>
-#include <zephyr/mgmt/mcumgr/mgmt/callbacks.h>
-#endif
-
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(state_indicator, CONFIG_LOG_DEFAULT_LEVEL);
 
 ZBUS_CHAN_DECLARE(bt_mgmt_chan);
 ZBUS_CHAN_DECLARE(battery_chan);
-
-#ifdef CONFIG_MCUMGR_MGMT_NOTIFICATION_HOOKS
-
-struct mgmt_callback mcu_mgr_cb;
-
-enum mgmt_cb_return chuck_write_indication(uint32_t event, enum mgmt_cb_return prev_status,
-                                int32_t *rc, uint16_t *group, bool *abort_more,
-                                void *data, size_t data_size)
-{
-    if (event == MGMT_EVT_OP_IMG_MGMT_DFU_CHUNK) {
-        /* This is the event we registered for */
-		led_controller.setColor(LED_ORANGE);
-        k_msleep(10);
-        led_controller.setColor(LED_OFF);
-    }
-    /*else if (event == MGMT_EVT_OP_IMG_MGMT_DFU_CHUNK_WRITE_COMPLETE) {
-        led_controller.setColor(LED_OFF);
-    }
-    else if (event == MGMT_EVT_OP_OS_MGMT_RESET) {
-		LOG_INF("RESET received");
-	}*/
-
-	//LOG_DBG("mcu mgr hook called with event: %d", event);
-
-    /* Return OK status code to continue with acceptance to underlying handler */
-    return MGMT_CB_OK;
-}
-
-#endif
 
 static void connect_evt_handler(const struct zbus_channel *chan)
 {
@@ -93,12 +59,6 @@ void StateIndicator::init(struct earable_state state) {
 	if (ret && ret != -EALREADY) {
 		LOG_ERR("Failed to add battery listener");
 	}
-
-#ifdef CONFIG_MCUMGR_MGMT_NOTIFICATION_HOOKS 
-	mcu_mgr_cb.callback = chuck_write_indication;
-    mcu_mgr_cb.event_id = MGMT_EVT_OP_IMG_MGMT_DFU_CHUNK; //MGMT_EVT_OP_IMG_MGMT_ALL
-    mgmt_callback_register(&mcu_mgr_cb);
-#endif
 
     set_state(state);
 }

--- a/src/utils/StateIndicator.cpp
+++ b/src/utils/StateIndicator.cpp
@@ -68,6 +68,15 @@ void StateIndicator::set_custom_color(const RGBColor &color) {
     if (_state.led_mode == CUSTOM) led_controller.setColor(color);
 }
 
+void StateIndicator::set_dfu_active(bool active) {
+    if (_dfu_active == active) {
+        return;
+    }
+
+    _dfu_active = active;
+    set_state(_state);
+}
+
 void StateIndicator::set_indication_mode(enum led_mode state) {
     _state.led_mode = state;
     set_state(_state);
@@ -91,6 +100,11 @@ void StateIndicator::set_sd_state(enum sd_state state) {
 
 void StateIndicator::set_state(struct earable_state state) {
     _state = state;
+
+    if (_dfu_active) {
+        led_controller.blink(LED_ORANGE, 100, 200);
+        return;
+    }
 
     // do not update the state if set to custom color
     if (_state.led_mode == CUSTOM) {
@@ -167,3 +181,8 @@ void StateIndicator::set_state(struct earable_state state) {
 }
 
 StateIndicator state_indicator;
+
+extern "C" void state_indicator_set_dfu_active(bool active)
+{
+    state_indicator.set_dfu_active(active);
+}

--- a/src/utils/StateIndicator.h
+++ b/src/utils/StateIndicator.h
@@ -24,10 +24,12 @@ public:
     void set_pairing_state(enum pairing_state state);
     void set_indication_mode(enum led_mode state);
     void set_custom_color(const RGBColor &color);
+    void set_dfu_active(bool active);
 
 private:
     earable_state _state;
     RGBColor color;
+    bool _dfu_active = false;
 };
 
 extern StateIndicator state_indicator;

--- a/src/utils/StateIndicatorC.h
+++ b/src/utils/StateIndicatorC.h
@@ -1,0 +1,16 @@
+#ifndef _STATE_INDICATOR_C_H_
+#define _STATE_INDICATOR_C_H_
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void state_indicator_set_dfu_active(bool active);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _STATE_INDICATOR_C_H_ */


### PR DESCRIPTION
Disable per-chunk LED flashes during FOTA, making image uploads more stable