### PR TITLE
FW: fix issues exposed by codechecker

### DIFF
--- a/src/Battery/BQ25120a.cpp
+++ b/src/Battery/BQ25120a.cpp
@@ -153,28 +153,28 @@ void BQ25120a::setup(const battery_settings &_battery_settings) {
 
 uint8_t BQ25120a::read_charging_state() {
         uint8_t status = 0;
-        bool ret = readReg(registers::CTRL, (uint8_t *) &status, sizeof(status));
+        (void)readReg(registers::CTRL, (uint8_t *) &status, sizeof(status));
 
         return status;
 }
 
 uint8_t BQ25120a::read_fault() {
         uint8_t status = 0;
-        bool ret = readReg(registers::FAULT, (uint8_t *) &status, sizeof(status));
+        (void)readReg(registers::FAULT, (uint8_t *) &status, sizeof(status));
 
         return status;
 }
 
 uint8_t BQ25120a::read_ts_fault() {
         uint8_t status = 0;
-        bool ret = readReg(registers::TS_FAULT, (uint8_t *) &status, sizeof(status));
+        (void)readReg(registers::TS_FAULT, (uint8_t *) &status, sizeof(status));
 
         return status;
 }
 
 chrg_state BQ25120a::read_charging_control() {
         uint8_t status = 0;
-        bool ret = readReg(registers::CHARGE_CTRL, (uint8_t *) &status, sizeof(status));
+        (void)readReg(registers::CHARGE_CTRL, (uint8_t *) &status, sizeof(status));
 
         chrg_state chrg;
 
@@ -200,7 +200,7 @@ chrg_state BQ25120a::read_charging_control() {
 
 uint8_t BQ25120a::write_charging_control(float mA) {
         uint8_t status = 0;
-        bool ret = readReg(registers::CHARGE_CTRL, &status, sizeof(status));
+        (void)readReg(registers::CHARGE_CTRL, &status, sizeof(status));
 
         status &= 0x3;
 
@@ -253,7 +253,7 @@ uint8_t BQ25120a::write_LDO_voltage_control(float volt) {
 
 float BQ25120a::read_ldo_voltage() {
         uint8_t status = 0;
-        bool ret = readReg(registers::LS_LDO_CTRL, (uint8_t *) &status, sizeof(status));
+        (void)readReg(registers::LS_LDO_CTRL, (uint8_t *) &status, sizeof(status));
 
         float voltage = 0.8f + ((status >> 2 & 0x1F)) * 0.1f;
 
@@ -262,7 +262,7 @@ float BQ25120a::read_ldo_voltage() {
 
 float BQ25120a::read_battery_voltage_control() {
         uint8_t status = 0;
-        bool ret = readReg(registers::BAT_VOL_CTRL, (uint8_t *) &status, sizeof(status));
+        (void)readReg(registers::BAT_VOL_CTRL, (uint8_t *) &status, sizeof(status));
 
         float voltage = 3.6f + (status >> 1) * 0.01f;
 
@@ -286,7 +286,7 @@ uint8_t BQ25120a::write_battery_voltage_control(float volt) {
 
 chrg_state BQ25120a::read_termination_control() {
         uint8_t status = 0;
-        bool ret = readReg(registers::TERM_CTRL, (uint8_t *) &status, sizeof(status));
+        (void)readReg(registers::TERM_CTRL, (uint8_t *) &status, sizeof(status));
 
         struct chrg_state chrg;
 
@@ -337,7 +337,7 @@ ilim_uvlo BQ25120a::read_uvlo_ilim() {
         struct ilim_uvlo param;
         uint8_t status = 0;
 
-        bool ret = readReg(registers::ILIM_UVLO, (uint8_t *) &status, sizeof(status));
+        (void)readReg(registers::ILIM_UVLO, (uint8_t *) &status, sizeof(status));
 
         param.uvlo_v = CLAMP(3.0f- 0.2f * ((status & 0x7) - 2), 2.2, 3.0);
         param.lim_mA = 50.f + 50.f * ((status >> 3) & 0x7);
@@ -402,7 +402,7 @@ button_state BQ25120a::read_button_state() {
         struct button_state btn;
 
         uint8_t status = 0;
-        bool ret = readReg(registers::BTN_CTRL, (uint8_t *) &status, sizeof(status));
+        (void)readReg(registers::BTN_CTRL, (uint8_t *) &status, sizeof(status));
 
         btn.wake_1 = status & 0x2;
         btn.wake_2 = status & 0x1;

--- a/src/Battery/BQ27220.cpp
+++ b/src/Battery/BQ27220.cpp
@@ -96,7 +96,7 @@ void BQ27220::writeReg(uint8_t reg, uint8_t *buffer, uint16_t len) {
 bat_status BQ27220::battery_status() {
         bat_status status;
         uint16_t val = 0;
-        bool ret = readReg(registers::FLAGS, (uint8_t *) &val, sizeof(val));
+        (void)readReg(registers::FLAGS, (uint8_t *) &val, sizeof(val));
 
         status.DSG = val & 0x1;
         status.SYSDWN = val & (1 << 1);
@@ -135,7 +135,7 @@ gauge_status BQ27220::gauging_state() {
 
 float BQ27220::temperature() {
         uint16_t temp_K = 0;
-        bool ret = readReg(registers::TEMP, (uint8_t *) &temp_K, sizeof(temp_K));
+        (void)readReg(registers::TEMP, (uint8_t *) &temp_K, sizeof(temp_K));
 
         float temp = temp_K / 10.0 - 273.15;
         return temp;
@@ -143,7 +143,7 @@ float BQ27220::temperature() {
 
 float BQ27220::voltage() {
         uint16_t mV = 0;
-        bool ret = readReg(registers::VOLT, (uint8_t *) &mV, sizeof(mV));
+        (void)readReg(registers::VOLT, (uint8_t *) &mV, sizeof(mV));
 
         float v = mV / 1000.0;
         return v;
@@ -151,74 +151,74 @@ float BQ27220::voltage() {
 
 float BQ27220::capacity() {
         uint16_t mAh = 0;
-        bool ret = readReg(registers::FCC, (uint8_t *) &mAh, sizeof(mAh));
+        (void)readReg(registers::FCC, (uint8_t *) &mAh, sizeof(mAh));
         return mAh;
 }
 
 float BQ27220::time_to_full() {
         uint16_t minutes = 0;
-        bool ret = readReg(registers::TTF, (uint8_t *) &minutes, sizeof(minutes));
+        (void)readReg(registers::TTF, (uint8_t *) &minutes, sizeof(minutes));
         return minutes;
 }
 
 
 float BQ27220::time_to_empty() {
         uint16_t minutes = 0;
-        bool ret = readReg(registers::TTE, (uint8_t *) &minutes, sizeof(minutes));
+        (void)readReg(registers::TTE, (uint8_t *) &minutes, sizeof(minutes));
         return minutes;
 }
 
 float BQ27220::state_of_charge() {
         uint16_t soc = 0;
-        bool ret = readReg(registers::SOC, (uint8_t *) &soc, sizeof(soc));
+        (void)readReg(registers::SOC, (uint8_t *) &soc, sizeof(soc));
         return soc;
 }
 
 float BQ27220::state_of_health() {
         uint16_t soc = 0;
-        bool ret = readReg(registers::SOH, (uint8_t *) &soc, sizeof(soc));
+        (void)readReg(registers::SOH, (uint8_t *) &soc, sizeof(soc));
         return soc;
 }
 
 float BQ27220::current() {
         int16_t mA = 0;
-        bool ret = readReg(registers::NAC, (uint8_t *) &mA, sizeof(mA));
+        (void)readReg(registers::NAC, (uint8_t *) &mA, sizeof(mA));
         return mA;
 }
 
 float BQ27220::average_current() {
         int16_t mA = 0;
-        bool ret = readReg(registers::AI, (uint8_t *) &mA, sizeof(mA));
+        (void)readReg(registers::AI, (uint8_t *) &mA, sizeof(mA));
         return mA;
 }
 
 float BQ27220::design_cap() {
         uint16_t mAh = 0;
-        bool ret = readReg(registers::DCAP, (uint8_t *) &mAh, sizeof(mAh));
+        (void)readReg(registers::DCAP, (uint8_t *) &mAh, sizeof(mAh));
         return mAh;
 }
 
 float BQ27220::remaining_cap() {
         uint16_t mAh = 0;
-        bool ret = readReg(registers::RM, (uint8_t *) &mAh, sizeof(mAh));
+        (void)readReg(registers::RM, (uint8_t *) &mAh, sizeof(mAh));
         return mAh;
 }
 
 float BQ27220::charge_current() {
         int16_t mA = 0;
-        bool ret = readReg(registers::CC, (uint8_t *) &mA, sizeof(mA));
+        (void)readReg(registers::CC, (uint8_t *) &mA, sizeof(mA));
         return mA;
 }
 
 int BQ27220::cycle_count() {
         uint16_t n_cycles = 0;
-        bool ret = readReg(registers::CYCT, (uint8_t *) &n_cycles, sizeof(n_cycles));
+        (void)readReg(registers::CYCT, (uint8_t *) &n_cycles, sizeof(n_cycles));
         return n_cycles;
 }
 
 float  BQ27220::standby_current() {
         int16_t mA = 0;
-        bool ret = readReg(registers::SI, (uint8_t *) &mA, sizeof(mA));
+        (void)readReg(registers::SI, (uint8_t *) &mA, sizeof(mA));
 
         return mA;
 }
@@ -226,7 +226,7 @@ float  BQ27220::standby_current() {
 op_state BQ27220::operation_state() {
         op_state state;
         uint16_t status = 0;
-        bool ret = readReg(registers::OP_STAT, (uint8_t *) &status, sizeof(status));
+        (void)readReg(registers::OP_STAT, (uint8_t *) &status, sizeof(status));
         
         state.CALD = status & 0x01;
         state.SEC = (status >> 1) & 0x3;
@@ -302,11 +302,9 @@ void BQ27220::exit_config_update(bool init) {
 }
 
 void BQ27220::read_RAM(uint16_t ram_address, uint8_t * data, int len) {
-        bool ret;
-
         writeReg(0x3E, (uint8_t *) &ram_address, sizeof(ram_address));
         k_usleep(BQ27220_RAM_TIMEOUT_US);
-        ret = readReg(0x40, data, len);
+        (void)readReg(0x40, data, len);
 }
 
 int BQ27220::write_RAM(uint16_t ram_address, uint8_t * data, int len, bool check) {
@@ -314,15 +312,13 @@ int BQ27220::write_RAM(uint16_t ram_address, uint8_t * data, int len, bool check
         uint8_t data_len=0;
         uint8_t buf[len];
 
-        bool ret;
-
         writeReg(0x3E, (uint8_t *) &ram_address, sizeof(ram_address));
 
         k_usleep(BQ27220_RAM_TIMEOUT_US);
 
-        ret = readReg(0x61, (uint8_t *) &data_len, sizeof(data_len));
-        ret = readReg(0x40, buf, len);
-        ret = readReg(0x60, (uint8_t *) &check_sum, sizeof(check_sum));
+        (void)readReg(0x61, (uint8_t *) &data_len, sizeof(data_len));
+        (void)readReg(0x40, buf, len);
+        (void)readReg(0x60, (uint8_t *) &check_sum, sizeof(check_sum));
 
         uint8_t my_check = (uint8_t)0xFF-check_sum; // - data[0] - data[1];
 
@@ -367,8 +363,6 @@ int BQ27220::write_RAM(uint16_t ram_address, uint16_t val, bool check) {
 }
 
 void BQ27220::setup(const battery_settings &_battery_settings, bool init) {
-        int ret;
-
         // unseal
         write_command(0x0414);
         k_msleep(100);
@@ -385,29 +379,29 @@ void BQ27220::setup(const battery_settings &_battery_settings, bool init) {
         //ret = write_RAM(0x9220, 0);
 
         // design and full charge capacity
-        ret = write_RAM(0x929F, _battery_settings.capacity);
-        ret = write_RAM(0x929D, _battery_settings.capacity); //130
+        (void)write_RAM(0x929F, _battery_settings.capacity);
+        (void)write_RAM(0x929D, _battery_settings.capacity); //130
         // near full
-        ret = write_RAM(0x926B, 5);
+        (void)write_RAM(0x926B, 5);
 
-        ret = write_RAM(0x91F5, _battery_settings.temp_min * 10);
-        ret = write_RAM(0x91F7, _battery_settings.temp_max * 10);
+        (void)write_RAM(0x91F5, _battery_settings.temp_min * 10);
+        (void)write_RAM(0x91F7, _battery_settings.temp_max * 10);
 
         // charge current
-        ret = write_RAM(0x91FB, _battery_settings.i_charge);
+        (void)write_RAM(0x91FB, _battery_settings.i_charge);
 
         // charge voltage
-        ret = write_RAM(0x91FD, _battery_settings.u_term * 1000);
+        (void)write_RAM(0x91FD, _battery_settings.u_term * 1000);
 
         // taper current
-        ret = write_RAM(0x9201, _battery_settings.i_term);
+        (void)write_RAM(0x9201, _battery_settings.i_term);
 
         // experimental: min taper capacity
-        ret = write_RAM(0x9203, 4); // standard: 25
+        (void)write_RAM(0x9203, 4); // standard: 25
 
         // deadband
         uint8_t val = 1;
-        ret = write_RAM(0x91DE, &val, sizeof(uint8_t));
+        (void)write_RAM(0x91DE, &val, sizeof(uint8_t));
         
         // deadband CC (verursacht Probleme, rm zählt zu schnell?)
         /*val = 5;
@@ -415,14 +409,14 @@ void BQ27220::setup(const battery_settings &_battery_settings, bool init) {
         */
         
         // sleep current
-        ret = write_RAM(0x9217, 1);
+        (void)write_RAM(0x9217, 1);
 
         // dischage current trd
-        ret = write_RAM(0x9228, 2);
+        (void)write_RAM(0x9228, 2);
         // charge current trd
-        ret = write_RAM(0x922A, 2);
+        (void)write_RAM(0x922A, 2);
         // quit current
-        ret = write_RAM(0x922C, 1);
+        (void)write_RAM(0x922C, 1);
 
         //dod  0%: 4287
         //dod 10%: 4125
@@ -444,29 +438,29 @@ void BQ27220::setup(const battery_settings &_battery_settings, bool init) {
         //dod: 103.25%: 3089
 
         // sysDown set Voltage
-        ret = write_RAM(0x9240, _battery_settings.u_vlo * 1000 + CONFIG_BATTERY_SYSDOWN_SET_OFFSET);
+        (void)write_RAM(0x9240, _battery_settings.u_vlo * 1000 + CONFIG_BATTERY_SYSDOWN_SET_OFFSET);
 
         // sysDown clear Voltage
-        ret = write_RAM(0x9243, _battery_settings.u_vlo * 1000 + CONFIG_BATTERY_SYSDOWN_SET_OFFSET + CONFIG_BATTERY_SYSDOWN_HYSTERESIS);
+        (void)write_RAM(0x9243, _battery_settings.u_vlo * 1000 + CONFIG_BATTERY_SYSDOWN_SET_OFFSET + CONFIG_BATTERY_SYSDOWN_HYSTERESIS);
 
         // FD set
-        ret = write_RAM(0x9282, _battery_settings.u_vlo * 1000 + CONFIG_BATTERY_FD_SET_OFFSET);
+        (void)write_RAM(0x9282, _battery_settings.u_vlo * 1000 + CONFIG_BATTERY_FD_SET_OFFSET);
 
         // FD clear
-        ret = write_RAM(0x9284, _battery_settings.u_vlo * 1000 + CONFIG_BATTERY_FD_SET_OFFSET + CONFIG_BATTERY_FD_HYSTERESIS); 
+        (void)write_RAM(0x9284, _battery_settings.u_vlo * 1000 + CONFIG_BATTERY_FD_SET_OFFSET + CONFIG_BATTERY_FD_HYSTERESIS);
 
         // FC Voltage
-        ret = write_RAM(0x9288, _battery_settings.u_term * 1000 - CONFIG_BATTERY_FC_VOLTAGE_OFFSET);
+        (void)write_RAM(0x9288, _battery_settings.u_term * 1000 - CONFIG_BATTERY_FC_VOLTAGE_OFFSET);
 
         // Electonic Load in 3µA steps
-        ret = write_RAM(0x9269, 6); // 18 µA
+        (void)write_RAM(0x9269, 6); // 18 µA
 
         // EMF
         //write_RAM(0x92A7, 36001);
         //C0
-        ret = write_RAM(0x92A9, 480); //bat1:250
+        (void)write_RAM(0x92A9, 480); //bat1:250
         //R0
-        ret = write_RAM(0x92AB, 19941); //bat1: 19941 //22542 //new bat:  17340
+        (void)write_RAM(0x92AB, 19941); //bat1: 19941 //22542 //new bat:  17340
         //R1
         //write_RAM(0x92AF, 3160);
 
@@ -478,16 +472,16 @@ void BQ27220::setup(const battery_settings &_battery_settings, bool init) {
         // do not use, only on CT makes sense:
         // SOC Flag, enable FC voltage detection
         uint8_t flags_b = 0x8C;
-        ret = write_RAM(0x9281, &flags_b, sizeof(flags_b));
+        (void)write_RAM(0x9281, &flags_b, sizeof(flags_b));
 
         // Overload current
-        ret = write_RAM(0x9264, _battery_settings.i_max);
+        (void)write_RAM(0x9264, _battery_settings.i_max);
 
         // CEDV Smoothing Config
         uint8_t cedv_conf = 0x0D; //Default: 0x08, Enable SMEXT, SMEN 0x0D
-        ret = write_RAM(0x9271, &cedv_conf, sizeof(cedv_conf));
+        (void)write_RAM(0x9271, &cedv_conf, sizeof(cedv_conf));
 
-        ret = write_RAM(0x9272, 3700);
+        (void)write_RAM(0x9272, 3700);
 
         exit_config_update(init);
 

--- a/src/Battery/PowerManager.cpp
+++ b/src/Battery/PowerManager.cpp
@@ -263,10 +263,12 @@ void PowerManager::fuel_gauge_work_handler(struct k_work * work) {
 }
 
 int PowerManager::begin() {
-    earable_state oe_state;
+    earable_state oe_state{};
 
     oe_state.charging_state = DISCHARGING;
     oe_state.pairing_state = PAIRED;
+    oe_state.sd_state = SD_IDLE;
+    oe_state.led_mode = STATE_INDICATION;
 
     battery_controller.begin();
     fuel_gauge.begin();

--- a/src/Battery/PowerManager.cpp
+++ b/src/Battery/PowerManager.cpp
@@ -2,6 +2,7 @@
 
 #include "macros_common.h"
 
+#include <cmath>
 #include <stdio.h>
 #include <zephyr/sys/poweroff.h>
 #include <zephyr/sys/reboot.h>
@@ -404,7 +405,7 @@ int PowerManager::begin() {
 
     // check if fuel gauge has wrong value
     float capacity = fuel_gauge.capacity();
-    if (abs(capacity - _battery_settings.capacity) > 1e-4) {
+    if (std::fabs(capacity - _battery_settings.capacity) > 1e-4F) {
         fuel_gauge.setup(_battery_settings);
         set_error_led();
     }

--- a/src/Battery/PowerManager.cpp
+++ b/src/Battery/PowerManager.cpp
@@ -543,7 +543,7 @@ void bt_disconnect_handler(struct bt_conn *conn, void * data) {
     if (ret != 0) return;
     
     if (info.state == BT_CONN_STATE_CONNECTED) {
-        ret = bt_mgmt_conn_disconnect(conn, *((uint8_t*)data));
+        (void)bt_mgmt_conn_disconnect(conn, *((uint8_t*)data));
     }
 }
 
@@ -554,7 +554,7 @@ void PowerManager::reboot() {
     uint8_t data = BT_HCI_ERR_REMOTE_USER_TERM_CONN;
     bt_conn_foreach(BT_CONN_TYPE_ALL, bt_disconnect_handler, &data);
 
-    ret = bt_le_adv_stop();
+    (void)bt_le_adv_stop();
 
     stop_sensor_manager();
 
@@ -573,7 +573,7 @@ int PowerManager::power_down(bool fault) {
     uint8_t data = BT_HCI_ERR_REMOTE_USER_TERM_CONN;
     bt_conn_foreach(BT_CONN_TYPE_ALL, bt_disconnect_handler, &data);
 
-    ret = bt_le_adv_stop();
+    (void)bt_le_adv_stop();
 
     // power disonnected
     // prepare interrupts
@@ -614,7 +614,7 @@ int PowerManager::power_down(bool fault) {
     }
     LOG_PANIC();
 
-    ret = bt_mgmt_stop_watchdog();
+    (void)bt_mgmt_stop_watchdog();
     //ERR_CHK(ret);
 
     dac.end();
@@ -631,10 +631,10 @@ int PowerManager::power_down(bool fault) {
         return 0;
     }
 
-    ret = pm_device_action_run(ls_sd,  PM_DEVICE_ACTION_SUSPEND);
-    ret = pm_device_action_run(ls_3_3, PM_DEVICE_ACTION_SUSPEND);
-    ret = pm_device_action_run(ls_1_8, PM_DEVICE_ACTION_SUSPEND);
-    ret = pm_device_action_run(cons,   PM_DEVICE_ACTION_SUSPEND);
+    (void)pm_device_action_run(ls_sd,  PM_DEVICE_ACTION_SUSPEND);
+    (void)pm_device_action_run(ls_3_3, PM_DEVICE_ACTION_SUSPEND);
+    (void)pm_device_action_run(ls_1_8, PM_DEVICE_ACTION_SUSPEND);
+    (void)pm_device_action_run(cons, PM_DEVICE_ACTION_SUSPEND);
 
     /*const struct device *const i2c = DEVICE_DT_GET(DT_NODELABEL(i2c1));
     ret = pm_device_action_run(i2c, PM_DEVICE_ACTION_SUSPEND);

--- a/src/SD_Card/SD_Card_Manager/SD_Card_Manager.cpp
+++ b/src/SD_Card/SD_Card_Manager/SD_Card_Manager.cpp
@@ -111,13 +111,11 @@ int SDCardManager::aquire_ls() {
 }
 
 int SDCardManager::release_ls() {
-	int ret;
-
 	if (!ls_aquired) return -EALREADY;
 
-	ret = pm_device_runtime_put(ls_1_8);
-	ret = pm_device_runtime_put(ls_3_3);
-	ret = pm_device_runtime_put(ls_sd);
+	(void)pm_device_runtime_put(ls_1_8);
+	(void)pm_device_runtime_put(ls_3_3);
+	(void)pm_device_runtime_put(ls_sd);
 
 	ls_aquired = false;
 
@@ -128,7 +126,7 @@ void SDCardManager::init() {
 	int ret;
 
     if (!device_is_ready(sd_state_pin.port)) {
-		ret = aquire_ls();
+		(void)aquire_ls();
         LOG_ERR("SD state GPIO device not ready\n");
         return;
     }
@@ -178,7 +176,7 @@ int SDCardManager::mount() {
 	uint32_t sector_count;
 	size_t sector_size;
 
-	ret = aquire_ls();
+	(void)aquire_ls();
 
 	bool _sd_inserted = sd_inserted();
 

--- a/src/SD_Card/SD_Card_Manager/SD_Card_Manager.cpp
+++ b/src/SD_Card/SD_Card_Manager/SD_Card_Manager.cpp
@@ -43,6 +43,9 @@ void SDCardManager::unmount_work_handler(struct k_work *work) {
 
     if (!_inserted) {
 		ret = sdcard_manager.unmount();
+		if (ret != 0) {
+			LOG_ERR("Failed to unmount SD card: %d", ret);
+		}
 		LOG_INF("SD card unmounted due to card removal.");
 		
 		ret = zbus_chan_pub(&sd_card_chan, &msg, K_FOREVER);

--- a/src/SensorManager/BMP388/Adafruit_BMP3XX.cpp
+++ b/src/SensorManager/BMP388/Adafruit_BMP3XX.cpp
@@ -112,9 +112,11 @@ bool Adafruit_BMP3XX::_init(void) {
   if (rslt != BMP3_OK)
     return false;
 
-  rslt = bmp3_init(&the_sensor);
 #ifdef BMP3XX_DEBUG
-  printk("Init result: %i\n", rslt);
+  const int8_t init_rslt = bmp3_init(&the_sensor);
+  printk("Init result: %i\n", init_rslt);
+#else
+  (void)bmp3_init(&the_sensor);
 #endif
 
   rslt = validate_trimming_param(&the_sensor);

--- a/src/SensorManager/BMP388/bmp3.c
+++ b/src/SensorManager/BMP388/bmp3.c
@@ -1089,7 +1089,7 @@ int8_t bmp3_extract_fifo_data(struct bmp3_data *data, struct bmp3_dev *dev)
     uint8_t header;
     uint8_t parsed_frames = 0;
     uint8_t t_p_frame;
-    struct bmp3_uncomp_data uncomp_data;
+    struct bmp3_uncomp_data uncomp_data = { 0 };
 
     rslt = null_ptr_check(dev);
 

--- a/src/SensorManager/BMP388/bmp3.c
+++ b/src/SensorManager/BMP388/bmp3.c
@@ -1028,17 +1028,17 @@ int8_t bmp3_get_fifo_data(struct bmp3_dev *dev)
         /* Get the total no of bytes available in FIFO */
         rslt = bmp3_get_fifo_length(&fifo_len, dev);
 
-        /* For sensor time frame */
-        if (dev->fifo->settings.time_en == TRUE)
-        {
-            fifo_len = fifo_len + 4;
-        }
-
-        /* Update the fifo length in the fifo structure */
-        dev->fifo->data.byte_count = fifo_len;
-
         if (rslt == BMP3_OK)
         {
+            /* For sensor time frame */
+            if (dev->fifo->settings.time_en == TRUE)
+            {
+                fifo_len = fifo_len + 4;
+            }
+
+            /* Update the fifo length in the fifo structure */
+            dev->fifo->data.byte_count = fifo_len;
+
             /* Read the fifo data */
             rslt = bmp3_get_regs(BMP3_REG_FIFO_DATA, fifo->data.buffer, fifo_len, dev);
         }

--- a/src/SensorManager/BMX160/DFRobot_BMX160.cpp
+++ b/src/SensorManager/BMX160/DFRobot_BMX160.cpp
@@ -92,15 +92,7 @@ void DFRobot_BMX160::wakeUp(){
 
 bool DFRobot_BMX160::softReset()
 {
-  int8_t rslt=BMX160_OK;
-  if (Obmx160 == NULL){
-    rslt = BMX160_E_NULL_PTR;
-  }  
-  rslt = _softReset(Obmx160);
-  if (rslt == 0)
-    return true;
-  else
-    return false;
+  return _softReset(Obmx160) == BMX160_OK;
 }
 
 int8_t DFRobot_BMX160:: _softReset(sBmx160Dev_t *dev)

--- a/src/SensorManager/Baro.cpp
+++ b/src/SensorManager/Baro.cpp
@@ -51,7 +51,10 @@ void Baro::update_sensor(struct k_work *work) {
 	msg_baro.data.size = 2 * sizeof(float);
 	msg_baro.data.time = micros();
 
-	float data[2] = {bmp.temperature, bmp.pressure};
+	float data[2] = {
+		static_cast<float>(bmp.temperature),
+		static_cast<float>(bmp.pressure),
+	};
 
 	memcpy(msg_baro.data.data, data, 2 * sizeof(float));
 

--- a/src/SensorManager/MAXM86161/MAXM86161.cpp
+++ b/src/SensorManager/MAXM86161/MAXM86161.cpp
@@ -146,7 +146,7 @@ int MAXM86161::read(ppg_sample * buffer) {
     if (status == 0){
         number_of_bytes = num_samples / LED_NUM * LED_NUM * BYTES_PER_CH;
         
-        status = _read_block(REG_FIFO_DATA, number_of_bytes, (uint8_t *) databuffer);
+        (void)_read_block(REG_FIFO_DATA, number_of_bytes, (uint8_t *) databuffer);
 
         for (int i=0; i < num_samples / LED_NUM * LED_NUM; i++) {
             int idx = BYTES_PER_CH * i;
@@ -436,7 +436,7 @@ int MAXM86161::_clear_interrupt(void)
 int MAXM86161::read_interrupt_state(int &value)
 {
     int status;
-    status = _read_from_reg(REG_IRQ_STATUS2, value);
+    (void)_read_from_reg(REG_IRQ_STATUS2, value);
     status = _read_from_reg(REG_IRQ_STATUS1, value);
     return status;
 }

--- a/src/SensorManager/MLX90632/MLX90632.cpp
+++ b/src/SensorManager/MLX90632/MLX90632.cpp
@@ -244,8 +244,6 @@ float MLX90632::getObjectTemp(status& returnError)
 
     double AMB = (sixRAM / 12.0) / VRta * pow(2, 19);
 
-    double sensorTemp = P_O + (AMB - P_R) / P_G + P_T * pow((AMB - P_R), 2);
-
     float S = (float)(lowerRAM + upperRAM) / 2.0;
     double VRto = nineRAM + Ka * (sixRAM / 12.0);
     double Sto = (S / 12.0) / VRto * (double)pow(2, 19);

--- a/src/SensorManager/SensorManager.cpp
+++ b/src/SensorManager/SensorManager.cpp
@@ -74,7 +74,7 @@ void sensor_chan_update(void *p1, void *p2, void *p3) {
     int ret;
 
 	while (1) {
-		ret = k_poll(&sensor_manager_evt, 1, K_FOREVER);
+		(void)k_poll(&sensor_manager_evt, 1, K_FOREVER);
 
 		k_msgq_get(&sensor_queue, &msg, K_FOREVER);
 

--- a/src/audio/audio_datapath.c
+++ b/src/audio/audio_datapath.c
@@ -31,6 +31,7 @@
 #include "Equalizer.h"
 #include "sdlogger_wrapper.h"
 #include "decimation_filter.h"
+#include "../SensorManager/SensorManager.h"
 #include "arm_math.h"
 #include "hw_codec.h"
 //#include "../drivers/ADAU1860.h"

--- a/src/audio/audio_datapath.c
+++ b/src/audio/audio_datapath.c
@@ -1085,6 +1085,7 @@ static void audio_datapath_i2s_blk_complete(uint32_t frame_start_ts_us, uint32_t
 {
 	int ret;
 	static bool underrun_condition;
+	static uint32_t released_tx_reuse_count;
 
 	alt_buffer_free(tx_buf_released);
 
@@ -1131,7 +1132,13 @@ static void audio_datapath_i2s_blk_complete(uint32_t frame_start_ts_us, uint32_t
 				 */
 				ret = alt_buffer_get((void **)&tx_buf);
 				if (ret) {
-					LOG_DBG("No alternative I2S TX buffer available; reusing released buffer");
+					released_tx_reuse_count++;
+					if (released_tx_reuse_count == 1U ||
+					    (released_tx_reuse_count % UNDERRUN_LOG_INTERVAL_BLKS) == 0U) {
+						LOG_WRN("No alternative I2S TX buffer available; "
+							"reusing released buffer as silence, total: %u",
+							(unsigned int)released_tx_reuse_count);
+					}
 					/* I2S no longer owns this buffer; recycle it as silence
 					 * instead of leaving tx_buf NULL.
 					 */

--- a/src/audio/audio_datapath.c
+++ b/src/audio/audio_datapath.c
@@ -1130,7 +1130,13 @@ static void audio_datapath_i2s_blk_complete(uint32_t frame_start_ts_us, uint32_t
 				 * use alternative buffers
 				 */
 				ret = alt_buffer_get((void **)&tx_buf);
-				ERR_CHK(ret);
+				if (ret) {
+					LOG_DBG("No alternative I2S TX buffer available; reusing released buffer");
+					/* I2S no longer owns this buffer; recycle it as silence
+					 * instead of leaving tx_buf NULL.
+					 */
+					tx_buf = (uint8_t *)tx_buf_released;
+				}
 
 				memset(tx_buf, 0, BLK_STEREO_SIZE_OCTETS);
 			}

--- a/src/audio/audio_system.c
+++ b/src/audio/audio_system.c
@@ -201,6 +201,7 @@ static void encoder_thread(void *arg1, void *arg2, void *arg3)
 				}
 
 				if (ret == -EINVAL || ret == -ENXIO || ret == -EPERM ||
+					ret == -ENODEV || ret == -ENOTSUP ||
 				    consecutive_encode_failures >= ENCODE_FAILURE_FATAL_THRESHOLD) {
 					ERR_CHK_MSG(ret, "Persistent/non-recoverable audio encode failure");
 				}

--- a/src/audio/audio_system.c
+++ b/src/audio/audio_system.c
@@ -34,6 +34,7 @@ LOG_MODULE_REGISTER(audio_system, CONFIG_AUDIO_SYSTEM_LOG_LEVEL);
 #define FIFO_RX_BLOCK_COUNT (CONFIG_FIFO_FRAME_SPLIT_NUM * CONFIG_FIFO_RX_FRAME_COUNT)
 
 #define DEBUG_INTERVAL_NUM     1000
+#define ENCODE_FAILURE_FATAL_THRESHOLD 100U
 #define TEST_TONE_BASE_FREQ_HZ 1000
 
 K_THREAD_STACK_DEFINE(encoder_thread_stack, CONFIG_ENCODER_STACK_SIZE);
@@ -135,7 +136,8 @@ static void encoder_thread(void *arg1, void *arg2, void *arg3)
 	static uint8_t *encoded_data;
 	//static size_t pcm_block_size;
 	static uint32_t test_tone_finite_pos;
-	static bool encode_failed;
+	static uint32_t encode_drop_count;
+	static uint32_t consecutive_encode_failures;
 
 	while (1) {
 		/* Don't start encoding until the stream needing it has started */
@@ -188,15 +190,28 @@ static void encoder_thread(void *arg1, void *arg2, void *arg3)
 			ret = sw_codec_encode(pcm_raw_data, FRAME_SIZE_BYTES, &encoded_data,
 					      &encoded_data_size);
 			if (ret) {
-				if (!encode_failed) {
-					LOG_WRN("Audio encode failed; dropping frames until recovery: %d", ret);
+				encode_drop_count++;
+				consecutive_encode_failures++;
+
+				if (consecutive_encode_failures == 1U ||
+				    (consecutive_encode_failures % ENCODE_FAILURE_FATAL_THRESHOLD) == 0U) {
+					LOG_WRN("Audio encode failed: ret=%d, dropped=%u, consecutive=%u",
+						ret, (unsigned int)encode_drop_count,
+						(unsigned int)consecutive_encode_failures);
 				}
-				encode_failed = true;
+
+				if (ret == -EINVAL || ret == -ENXIO || ret == -EPERM ||
+				    consecutive_encode_failures >= ENCODE_FAILURE_FATAL_THRESHOLD) {
+					ERR_CHK_MSG(ret, "Persistent/non-recoverable audio encode failure");
+				}
+
 				continue;
 			}
-			if (encode_failed) {
-				LOG_INF("Audio encoder recovered");
-				encode_failed = false;
+
+			if (consecutive_encode_failures) {
+				LOG_INF("Audio encoder recovered after %u dropped frame(s)",
+					(unsigned int)consecutive_encode_failures);
+				consecutive_encode_failures = 0U;
 			}
 		}
 

--- a/src/audio/audio_system.c
+++ b/src/audio/audio_system.c
@@ -34,7 +34,6 @@ LOG_MODULE_REGISTER(audio_system, CONFIG_AUDIO_SYSTEM_LOG_LEVEL);
 #define FIFO_RX_BLOCK_COUNT (CONFIG_FIFO_FRAME_SPLIT_NUM * CONFIG_FIFO_RX_FRAME_COUNT)
 
 #define DEBUG_INTERVAL_NUM     1000
-#define ENCODE_FAILURE_FATAL_THRESHOLD 100U
 #define TEST_TONE_BASE_FREQ_HZ 1000
 
 K_THREAD_STACK_DEFINE(encoder_thread_stack, CONFIG_ENCODER_STACK_SIZE);
@@ -136,8 +135,7 @@ static void encoder_thread(void *arg1, void *arg2, void *arg3)
 	static uint8_t *encoded_data;
 	//static size_t pcm_block_size;
 	static uint32_t test_tone_finite_pos;
-	static uint32_t encode_drop_count;
-	static uint32_t consecutive_encode_failures;
+	static bool encode_failed;
 
 	while (1) {
 		/* Don't start encoding until the stream needing it has started */
@@ -190,29 +188,16 @@ static void encoder_thread(void *arg1, void *arg2, void *arg3)
 			ret = sw_codec_encode(pcm_raw_data, FRAME_SIZE_BYTES, &encoded_data,
 					      &encoded_data_size);
 			if (ret) {
-				encode_drop_count++;
-				consecutive_encode_failures++;
-
-				if (consecutive_encode_failures == 1U ||
-				    (consecutive_encode_failures % ENCODE_FAILURE_FATAL_THRESHOLD) == 0U) {
-					LOG_WRN("Audio encode failed: ret=%d, dropped=%u, consecutive=%u",
-						ret, (unsigned int)encode_drop_count,
-						(unsigned int)consecutive_encode_failures);
+				if (!encode_failed) {
+					LOG_WRN("Audio encode failed; dropping frames until recovery: %d", ret);
 				}
-
-				if (ret == -EINVAL || ret == -ENXIO || ret == -EPERM ||
-					ret == -ENODEV || ret == -ENOTSUP ||
-				    consecutive_encode_failures >= ENCODE_FAILURE_FATAL_THRESHOLD) {
-					ERR_CHK_MSG(ret, "Persistent/non-recoverable audio encode failure");
-				}
-
+				encode_failed = true;
 				continue;
 			}
 
-			if (consecutive_encode_failures) {
-				LOG_INF("Audio encoder recovered after %u dropped frame(s)",
-					(unsigned int)consecutive_encode_failures);
-				consecutive_encode_failures = 0U;
+			if (encode_failed) {
+				LOG_INF("Audio encoder recovered");
+				encode_failed = false;
 			}
 		}
 

--- a/src/audio/audio_system.c
+++ b/src/audio/audio_system.c
@@ -135,6 +135,7 @@ static void encoder_thread(void *arg1, void *arg2, void *arg3)
 	static uint8_t *encoded_data;
 	//static size_t pcm_block_size;
 	static uint32_t test_tone_finite_pos;
+	static bool encode_failed;
 
 	while (1) {
 		/* Don't start encoding until the stream needing it has started */
@@ -186,8 +187,17 @@ static void encoder_thread(void *arg1, void *arg2, void *arg3)
 
 			ret = sw_codec_encode(pcm_raw_data, FRAME_SIZE_BYTES, &encoded_data,
 					      &encoded_data_size);
-
-			ERR_CHK_MSG(ret, "Encode failed");
+			if (ret) {
+				if (!encode_failed) {
+					LOG_WRN("Audio encode failed; dropping frames until recovery: %d", ret);
+				}
+				encode_failed = true;
+				continue;
+			}
+			if (encode_failed) {
+				LOG_INF("Audio encoder recovered");
+				encode_failed = false;
+			}
 		}
 
 		/* Print block usage */

--- a/src/audio/audio_system.c
+++ b/src/audio/audio_system.c
@@ -138,7 +138,7 @@ static void encoder_thread(void *arg1, void *arg2, void *arg3)
 
 	while (1) {
 		/* Don't start encoding until the stream needing it has started */
-		ret = k_poll(&encoder_evt, 1, K_FOREVER);
+		(void)k_poll(&encoder_evt, 1, K_FOREVER);
 
 		/* Get PCM data from I2S */
 		/* Since one audio frame is divided into a number of

--- a/src/audio/streamctrl.c
+++ b/src/audio/streamctrl.c
@@ -558,6 +558,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type, st
     bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 
 	bool is_le_audio_device = false;
+	bool csis_rsi_found = false;
 	uint8_t csis_rsi[6];
 	uint8_t chip_id[8];
 
@@ -587,8 +588,14 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type, st
 			memcpy(chip_id, data, sizeof(chip_id));
         }
 
+		/* A valid RSI contains a 3-byte hash followed by a 3-byte random value. */
 		if (type == BT_DATA_CSIS_RSI) {
-			memcpy(csis_rsi, data, sizeof(csis_rsi));
+			if ((len - 1) >= sizeof(csis_rsi)) {
+				memcpy(csis_rsi, data, sizeof(csis_rsi));
+				csis_rsi_found = true;
+			} else {
+				LOG_DBG("Ignoring short CSIS RSI (%u bytes)", (unsigned int)(len - 1));
+			}
 		}
 
 		// channel
@@ -600,7 +607,6 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type, st
 	if (is_le_audio_device) {
 		LOG_INF("Found LE-Audio device!");
 
-		uint32_t hash_ref = (csis_rsi[2] << 16) | (csis_rsi[1] << 8) | csis_rsi[0];
 		uint32_t hash;
 
 		uint32_t new_sirk = *((uint32_t *) chip_id) ^ oe_boot_state.device_id;
@@ -620,6 +626,14 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type, st
 
 			write_sirk(new_sirk);
 		} else if (channel == AUDIO_CH_R) {
+			/* Only right-channel matching validates the advertised RSI. */
+			if (!csis_rsi_found) {
+				LOG_DBG("Ignoring right-channel LE Audio device without CSIS RSI");
+				return;
+			}
+
+			uint32_t hash_ref =
+				(csis_rsi[2] << 16) | (csis_rsi[1] << 8) | csis_rsi[0];
 			uint8_t res[BT_CSIP_PADDED_RAND_SIZE];
 
 			uint8_t sirk[BT_CSIP_SIRK_SIZE + 1];

--- a/src/audio/streamctrl.c
+++ b/src/audio/streamctrl.c
@@ -639,6 +639,10 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type, st
 			snprintf(sirk, BT_CSIP_SIRK_SIZE, "%08X", new_sirk);
 
 			int err = bt_encrypt_le(sirk, res, res);
+			if (err) {
+				LOG_ERR("Failed to calculate CSIS hash: %d", err);
+				return;
+			}
 
 			memcpy(out, res, BT_CSIP_CRYPTO_HASH_SIZE);
 

--- a/src/audio/streamctrl.c
+++ b/src/audio/streamctrl.c
@@ -559,6 +559,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type, st
 
 	bool is_le_audio_device = false;
 	bool csis_rsi_found = false;
+	bool chip_id_found = false;
 	uint8_t csis_rsi[6];
 	uint8_t chip_id[8];
 
@@ -584,8 +585,13 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type, st
         }
 
 		if (is_le_audio_device && type == BT_DATA_MANUFACTURER_DATA) {
-			memset(chip_id, 0, sizeof(chip_id));
-			memcpy(chip_id, data, sizeof(chip_id));
+			if ((len - 1) >= sizeof(chip_id)) {
+				memcpy(chip_id, data, sizeof(chip_id));
+				chip_id_found = true;
+			} else {
+				LOG_DBG("Ignoring short manufacturer chip ID (%u bytes)",
+					(unsigned int)(len - 1));
+			}
         }
 
 		/* A valid RSI contains a 3-byte hash followed by a 3-byte random value. */
@@ -607,9 +613,18 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type, st
 	if (is_le_audio_device) {
 		LOG_INF("Found LE-Audio device!");
 
-		uint32_t hash;
+		/* Do not derive or persist a SIRK without a complete peer identity. */
+		if (!chip_id_found) {
+			LOG_DBG("Ignoring LE Audio device without manufacturer chip ID");
+			return;
+		}
 
-		uint32_t new_sirk = *((uint32_t *) chip_id) ^ oe_boot_state.device_id;
+		uint32_t hash;
+		uint32_t peer_device_id;
+
+		/* Advertisement storage may not be aligned for a uint32_t access. */
+		memcpy(&peer_device_id, chip_id, sizeof(peer_device_id));
+		uint32_t new_sirk = peer_device_id ^ oe_boot_state.device_id;
 
 		enum audio_channel channel;
 
@@ -618,7 +633,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type, st
 
 		if (channel == AUDIO_CH_L) {
 			LOG_INF("Device ID 1: %016X", oe_boot_state.device_id);
-			LOG_INF("Device ID 2: %016X", *((uint32_t *) chip_id));
+			LOG_INF("Device ID 2: %016X", peer_device_id);
 			LOG_INF("New Sirk: %016X", new_sirk);
 
 			//TODO: check if the device wants to pair (sirk == device_id)

--- a/src/audio/streamctrl.c
+++ b/src/audio/streamctrl.c
@@ -557,7 +557,6 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type, st
     char addr_str[BT_ADDR_LE_STR_LEN];
     bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 
-    int ret;
 	bool is_le_audio_device = false;
 	uint8_t csis_rsi[6];
 	uint8_t chip_id[8];

--- a/src/audio/streamctrl.c
+++ b/src/audio/streamctrl.c
@@ -6,6 +6,9 @@
 
 #include "streamctrl.h"
 
+#include <stdio.h>
+#include <string.h>
+#include "common/bt_str.h"
 #include <zephyr/zbus/zbus.h>
 #include <zephyr/sys/reboot.h>
 
@@ -28,6 +31,8 @@
 
 #include "AutoOffManager.h"
 #include "BootState.h"
+#include "channel_assignment.h"
+#include "uicr.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(streamctrl, CONFIG_MAIN_LOG_LEVEL);

--- a/src/audio/streamctrl.c
+++ b/src/audio/streamctrl.c
@@ -576,7 +576,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type, st
 
         // Suchen nach 16-bit Service UUIDs (LE Audio Services)
         if (type == BT_DATA_SVC_DATA16) {
-            for (size_t i = 0; i < len - 1; i += 2) {
+            for (size_t i = 0; i + 1U < (size_t)(len - 1); i += 2) {
                 uint16_t uuid = (data[i + 1] << 8) | data[i];
 				if (uuid == BT_UUID_CAS_VAL) {
 					is_le_audio_device = true;

--- a/src/audio/streamctrl.c
+++ b/src/audio/streamctrl.c
@@ -622,7 +622,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type, st
 		uint32_t hash;
 		uint32_t peer_device_id;
 
-		/* Advertisement storage may not be aligned for a uint32_t access. */
+		/* Copy from the byte array without alignment or aliasing assumptions. */
 		memcpy(&peer_device_id, chip_id, sizeof(peer_device_id));
 		uint32_t new_sirk = peer_device_id ^ oe_boot_state.device_id;
 

--- a/src/audio/sw_codec_select.c
+++ b/src/audio/sw_codec_select.c
@@ -163,6 +163,15 @@ int sw_codec_encode(void *pcm_data, size_t pcm_size, uint8_t **encoded_data, siz
 			break;
 		}
 		case SW_CODEC_STEREO: {
+			/* Stereo encoding consumes both channel pointers below. Reject mismatched
+			 * configurations so the caller can drop the frame safely.
+			 */
+			if (m_config.encoder.num_ch != AUDIO_CH_NUM) {
+				LOG_DBG("Rejecting stereo encode with %u configured channels",
+					(unsigned int)m_config.encoder.num_ch);
+				return -EINVAL;
+			}
+
 			for (int i = 0; i < m_config.encoder.num_ch; ++i) {
 				ret = sw_codec_sample_rate_convert(
 					&encoder_converters[i], CONFIG_AUDIO_SAMPLE_RATE_HZ,

--- a/src/audio/sw_codec_select.c
+++ b/src/audio/sw_codec_select.c
@@ -247,13 +247,19 @@ int sw_codec_decode(uint8_t const *const encoded_data, size_t encoded_size, bool
 	switch (m_config.sw_codec) {
 	case SW_CODEC_LC3: {
 #if (CONFIG_SW_CODEC_LC3)
-		char *pcm_in_data_ptrs[m_config.decoder.channel_mode];
+		/* PLC override bypasses sample-rate conversion, so its branches assign these
+		 * fixed channel slots directly to zero-filled PCM buffers.
+		 */
+		char *pcm_in_data_ptrs[AUDIO_CH_NUM] = {0};
 
 		switch (m_config.decoder.channel_mode) {
 		case SW_CODEC_MONO: {
 			if (bad_frame && IS_ENABLED(CONFIG_SW_CODEC_OVERRIDE_PLC)) {
 				memset(decoded_data_mono[AUDIO_CH_L], 0, PCM_NUM_BYTES_MONO);
 				decoded_data_size = PCM_NUM_BYTES_MONO;
+				pcm_in_data_ptrs[AUDIO_CH_L] = decoded_data_mono[AUDIO_CH_L];
+				pcm_size_mono = decoded_data_size;
+				LOG_DBG("Replacing bad mono frame with silence");
 			} else {
 				ret = sw_codec_lc3_dec_run(
 					encoded_data, encoded_size, LC3_PCM_NUM_BYTES_MONO, 0,
@@ -293,6 +299,10 @@ int sw_codec_decode(uint8_t const *const encoded_data, size_t encoded_size, bool
 				memset(decoded_data_mono[AUDIO_CH_L], 0, PCM_NUM_BYTES_MONO);
 				memset(decoded_data_mono[AUDIO_CH_R], 0, PCM_NUM_BYTES_MONO);
 				decoded_data_size = PCM_NUM_BYTES_MONO;
+				pcm_in_data_ptrs[AUDIO_CH_L] = decoded_data_mono[AUDIO_CH_L];
+				pcm_in_data_ptrs[AUDIO_CH_R] = decoded_data_mono[AUDIO_CH_R];
+				pcm_size_mono = decoded_data_size;
+				LOG_DBG("Replacing bad stereo frame with silence");
 			} else {
 				/* Decode left channel */
 				ret = sw_codec_lc3_dec_run(
@@ -313,7 +323,8 @@ int sw_codec_decode(uint8_t const *const encoded_data, size_t encoded_size, bool
 					return ret;
 				}
 
-				for (int i = 0; i < m_config.decoder.channel_mode; ++i) {
+				/* Stereo always initializes both slots consumed by pscm_combine(). */
+				for (int i = 0; i < AUDIO_CH_NUM; ++i) {
 					ret = sw_codec_sample_rate_convert(
 						&decoder_converters[i],
 						m_config.decoder.sample_rate_hz,

--- a/src/bluetooth/bt_management/bt_mgmt.c
+++ b/src/bluetooth/bt_management/bt_mgmt.c
@@ -165,7 +165,7 @@ static void connected_cb(struct bt_conn *conn, uint8_t err)
 	err = bt_conn_le_param_update(conn, conn_param);
 	if (err) {
 		LOG_ERR("Cannot update conneciton parameter (err: %d)", err);
-		return err;
+		return;
 	}
 	LOG_INF("Connection parameters update requested: interval_min %d interval_max %d latency %d timeout %d",
 		conn_param->interval_min, conn_param->interval_max,

--- a/src/bluetooth/bt_management/bt_mgmt.c
+++ b/src/bluetooth/bt_management/bt_mgmt.c
@@ -6,6 +6,7 @@
 
 #include "bt_mgmt.h"
 
+#include <stdio.h>
 #include "channel_assignment.h"
 
 #include <zephyr/zbus/zbus.h>
@@ -19,6 +20,7 @@
 #include "macros_common.h"
 #include "zbus_common.h"
 #include "button_assignments.h"
+#include "uicr.h"
 
 #include "bt_mgmt_ctlr_cfg_internal.h"
 #include "bt_mgmt_adv_internal.h"

--- a/src/bluetooth/bt_management/scanning/bt_mgmt_scan.c
+++ b/src/bluetooth/bt_management/scanning/bt_mgmt_scan.c
@@ -55,9 +55,13 @@ int bt_mgmt_scan_start(uint16_t scan_intvl, uint16_t scan_win, enum bt_mgmt_scan
 		scan_window = scan_win;
 	}
 
-	struct bt_le_scan_param *scan_param =
+	struct bt_le_scan_param *scan_param;
+
+#if defined(CONFIG_BT_CENTRAL) || defined(CONFIG_BT_BAP_BROADCAST_SINK)
+	scan_param =
 		BT_LE_SCAN_PARAM(NRF5340_AUDIO_GATEWAY_SCAN_TYPE, BT_LE_SCAN_OPT_FILTER_DUPLICATE,
 				 scan_interval, scan_window);
+#endif
 
 	if (type == BT_MGMT_SCAN_TYPE_CONN && IS_ENABLED(CONFIG_BT_CENTRAL)) {
 		ret = bt_mgmt_scan_for_conn_start(scan_param, srch_name);

--- a/src/bluetooth/bt_management/scanning/bt_mgmt_scan.c
+++ b/src/bluetooth/bt_management/scanning/bt_mgmt_scan.c
@@ -55,7 +55,7 @@ int bt_mgmt_scan_start(uint16_t scan_intvl, uint16_t scan_win, enum bt_mgmt_scan
 		scan_window = scan_win;
 	}
 
-	struct bt_le_scan_param *scan_param;
+	struct bt_le_scan_param *scan_param = NULL;
 
 #if defined(CONFIG_BT_CENTRAL) || defined(CONFIG_BT_BAP_BROADCAST_SINK)
 	scan_param =

--- a/src/bluetooth/bt_stream/bt_le_audio_tx/bt_le_audio_tx.c
+++ b/src/bluetooth/bt_stream/bt_le_audio_tx/bt_le_audio_tx.c
@@ -96,10 +96,6 @@ static int iso_stream_send(uint8_t const *const data, size_t size, struct bt_cap
 	 */
 	if (atomic_get(&tx_info->iso_tx_pool_alloc) >= HCI_ISO_BUF_PER_CHAN) {
 		if (!tx_info->hci_wrn_printed) {
-			struct bt_iso_chan *iso_chan;
-
-			iso_chan = bt_bap_stream_iso_chan_get(&cap_stream->bap_stream);
-
 			LOG_WRN("HCI ISO TX overrun on stream %p - Single print",
 				(void *)&cap_stream->bap_stream);
 			tx_info->hci_wrn_printed = true;

--- a/src/bluetooth/bt_stream/unicast/unicast_server.c
+++ b/src/bluetooth/bt_stream/unicast/unicast_server.c
@@ -6,6 +6,8 @@
 
  #include "unicast_server.h"
 
+ #include <stdio.h>
+ #include <string.h>
  #include <zephyr/zbus/zbus.h>
  #include <zephyr/sys/byteorder.h>
  #include <zephyr/bluetooth/bluetooth.h>
@@ -20,7 +22,9 @@
  #include "zbus_common.h"
  #include "bt_mgmt.h"
  #include "bt_le_audio_tx.h"
+ #include "channel_assignment.h"
  #include "le_audio.h"
+ #include "uicr.h"
 
 #include "BootState.h"
  

--- a/src/bluetooth/bt_stream/unicast/unicast_server.c
+++ b/src/bluetooth/bt_stream/unicast/unicast_server.c
@@ -712,7 +712,8 @@ static uint8_t device_identifier[] = {
 		if (sirk != 0xFFFFFFFF) {
 			snprintf(sirk_string, 16, "%08X", sirk); //"%016llX"
 		} else {
-			snprintf(sirk_string, 16, "%08X", oe_boot_state.device_id); //"%016llX"
+			snprintf(sirk_string, 16, "%08X",
+				 (unsigned int)oe_boot_state.device_id); //"%016llX"
 		}
 
 		// LOG_INF("SIRK as String: %s", sirk_string);
@@ -806,4 +807,3 @@ static uint8_t device_identifier[] = {
  
 	 return 0;
  }
- 

--- a/src/bluetooth/gatt_services/audio_config_service.c
+++ b/src/bluetooth/gatt_services/audio_config_service.c
@@ -21,7 +21,11 @@ static ssize_t write_audio_mode(struct bt_conn *conn, const struct bt_gatt_attr 
         return BT_GATT_ERR(BT_ATT_ERR_VALUE_NOT_ALLOWED);
     }
 
-    hw_codec_set_audio_mode((enum audio_mode)mode);
+    int ret = hw_codec_set_audio_mode((enum audio_mode)mode);
+    if (ret) {
+        return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
+    }
+
     return len;
 }
 

--- a/src/bluetooth/gatt_services/device_info.c
+++ b/src/bluetooth/gatt_services/device_info.c
@@ -19,7 +19,8 @@ static ssize_t read_device_identifier(struct bt_conn *conn,
 			  uint16_t len,
 			  uint16_t offset)
 {
-	snprintf(device_identifier, sizeof(device_identifier), "0x%08X", oe_boot_state.device_id);
+	snprintf(device_identifier, sizeof(device_identifier), "0x%08X",
+		 (unsigned int)oe_boot_state.device_id);
 	
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, device_identifier,
 					 sizeof(device_identifier));

--- a/src/bluetooth/gatt_services/device_info.c
+++ b/src/bluetooth/gatt_services/device_info.c
@@ -1,4 +1,6 @@
 #include "device_info.h"
+#include <stdio.h>
+#include <string.h>
 #include <generated/version.h>
 
 #include <zephyr/bluetooth/bluetooth.h>

--- a/src/buttons/Button.cpp
+++ b/src/buttons/Button.cpp
@@ -15,12 +15,11 @@ struct gpio_callback Button::button_cb_data;
 void Button::button_isr(const struct device *dev, struct gpio_callback *cb,
 		    uint32_t pins)
 {
-	Button * button;
-
-	if (pins & BIT(BUTTON_EARABLE)) {
-		//earable_btn._read_state();
-		button = &earable_btn;
+	if (!(pins & BIT(BUTTON_EARABLE))) {
+		return;
 	}
+
+	Button *button = &earable_btn;
 
 	/*if (pins & BIT(BUTTON_VOLUME_UP)) {
 		volume_up_btn._read_state();

--- a/src/drivers/ADAU1860.cpp
+++ b/src/drivers/ADAU1860.cpp
@@ -591,11 +591,12 @@ int cmd_dsp_noise_gate(const struct shell *shell, size_t argc, char **argv) {
 
     safe_load_params params;
 
-    params[0] = strtoul(argv[1], NULL, 16) | 0xC80;
-    params[1] = strtoul(argv[2], NULL, 16) | 0xD00;
-    params[2] = strtoul(argv[3], NULL, 16);
-    params[3] = strtoul(argv[4], NULL, 16);
-    params[4] = strtoul(argv[5], NULL, 16) | 0x80000000;
+    params[0] = static_cast<uint32_t>(strtoul(argv[1], nullptr, 16)) | 0xC80U;
+    params[1] = static_cast<uint32_t>(strtoul(argv[2], nullptr, 16)) | 0xD00U;
+    params[2] = static_cast<uint32_t>(strtoul(argv[3], nullptr, 16));
+    params[3] = static_cast<uint32_t>(strtoul(argv[4], nullptr, 16));
+    params[4] =
+        static_cast<uint32_t>(strtoul(argv[5], nullptr, 16)) | 0x80000000U;
 
     shell_print(shell, "Params:");
     for (int i = 0; i < FDSP_NUM_PARAMS; i++) {

--- a/src/drivers/ADAU1860.cpp
+++ b/src/drivers/ADAU1860.cpp
@@ -2,6 +2,7 @@
 #include "zbus_common.h"
 #include "openearable_common.h"
 #include <math.h>
+#include <stdlib.h>
 
 #include <zephyr/logging/log_ctrl.h>
 #include <zephyr/logging/log.h>

--- a/src/drivers/LED_Controller/KTD2026.cpp
+++ b/src/drivers/LED_Controller/KTD2026.cpp
@@ -95,10 +95,17 @@ void KTD2026::begin() {
 
         if (_active) return;
 
-	_active = true;
+        _active = true;
         
         ret = pm_device_runtime_get(ls_1_8);
+        if (ret) {
+                LOG_ERR("Failed to enable 1.8 V LED supply: %d", ret);
+        }
+
         ret = pm_device_runtime_get(ls_3_3);
+        if (ret) {
+                LOG_ERR("Failed to enable 3.3 V LED supply: %d", ret);
+        }
 
         _i2c->begin();
 
@@ -121,7 +128,14 @@ void KTD2026::power_off() {
         (void)writeReg(registers::CTRL, &val, sizeof(val));
 
         int ret = pm_device_runtime_put(ls_1_8);
+        if (ret) {
+                LOG_ERR("Failed to disable 1.8 V LED supply: %d", ret);
+        }
+
         ret = pm_device_runtime_put(ls_3_3);
+        if (ret) {
+                LOG_ERR("Failed to disable 3.3 V LED supply: %d", ret);
+        }
 
         clearCachedColor();
 

--- a/src/modules/hw_codec_adau1860.cpp
+++ b/src/modules/hw_codec_adau1860.cpp
@@ -63,16 +63,13 @@ static int settings_set_cb(const char *name, size_t len, settings_read_cb read_c
 SETTINGS_STATIC_HANDLER_DEFINE(audio, "audio", NULL, settings_set_cb, NULL, NULL);
 
 int hw_codec_set_audio_mode(enum audio_mode mode) {
-    int ret;
-
-	audio_mode = mode;
-
-	settings_save_one("audio/mode", &mode, sizeof(mode));
+	int first_error = 0;
+	int ret;
 
 	ret = dac.fdsp_bank_select((uint8_t) mode);
 	if (ret) {
 		LOG_ERR("Failed to select DSP bank, ret: %d", ret);
-		return ret;
+		first_error = ret;
 	}
 
 	// TODO: make writing to bank work
@@ -80,12 +77,28 @@ int hw_codec_set_audio_mode(enum audio_mode mode) {
 	ret = hw_codec_volume_adjust(0);
 	if (ret) {
 		LOG_ERR("Failed to adjust codec volume, ret: %d", ret);
-		return ret;
+		if (!first_error) {
+			first_error = ret;
+		}
 	}
 
 	ret = dac.mute(muted);
 	if (ret) {
 		LOG_ERR("Failed to set audio mode, ret: %d", ret);
+		if (!first_error) {
+			first_error = ret;
+		}
+	}
+
+	if (first_error) {
+		/* Keep the persisted mode unchanged when the codec could not fully apply it. */
+		return first_error;
+	}
+
+	audio_mode = mode;
+	ret = settings_save_one("audio/mode", &mode, sizeof(mode));
+	if (ret) {
+		LOG_ERR("Failed to persist audio mode, ret: %d", ret);
 		return ret;
 	}
 

--- a/src/modules/hw_codec_adau1860.cpp
+++ b/src/modules/hw_codec_adau1860.cpp
@@ -70,15 +70,26 @@ int hw_codec_set_audio_mode(enum audio_mode mode) {
 	settings_save_one("audio/mode", &mode, sizeof(mode));
 
 	ret = dac.fdsp_bank_select((uint8_t) mode);
+	if (ret) {
+		LOG_ERR("Failed to select DSP bank, ret: %d", ret);
+		return ret;
+	}
+
 	// TODO: make writing to bank work
 	k_msleep(200);
 	ret = hw_codec_volume_adjust(0);
+	if (ret) {
+		LOG_ERR("Failed to adjust codec volume, ret: %d", ret);
+		return ret;
+	}
+
 	ret = dac.mute(muted);
 	if (ret) {
 		LOG_ERR("Failed to set audio mode, ret: %d", ret);
 		return ret;
 	}
-	return ret;
+
+	return 0;
 }
 
 enum audio_mode hw_codec_get_audio_mode() {


### PR DESCRIPTION
Fix issues exposed by CodeChecker workflow

- Fixed uninitialized values, invalid pointer paths, narrowing conversions, and incorrect return handling reported by CodeChecker.
- Added validation for Bluetooth advertisement data, audio channel configuration, BMP388 FIFO reads, and GPIO interrupts.
- Improved error logging and propagation while preserving existing behavior where possible.
- Added safe fallbacks for audio underruns and missing codec data.

Some CodeChecker findings were intentionally silenced while preserving existing behavior instead of redesigning the underlying error handling. For example, several ignored driver return values were made explicit with `(void)` casts.

Possible follow-up issues:

- Refactor battery, SD-card, MAXM86161, LED, and shutdown APIs to propagate errors currently discarded with `(void)`.
- Handle `bmp3_init()` failures and ensure FIFO pressure compensation only uses valid temperature data.
- Validate codec channel configuration during initialization and investigate the underlying I2S alternative-buffer exhaustion.
- Formalize device/chip-ID widths and endianness, and extract advertisement parsing into independently tested logic.
