### PR TITLE
fix(flash): boot FOTA firmware automatically after programming

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ If you are building from a workspace where this repository is checked out as an 
 
 ### Flashing And Recovery
 
-- Use [tools/flash/flash_fota.sh](tools/flash/flash_fota.sh) to flash a FOTA build with the correct left/right and hardware configuration flags.
+- Use [tools/flash/flash_fota.sh](tools/flash/flash_fota.sh) to flash a FOTA build with the correct left/right and hardware configuration flags. A successful flash performs a full-device reset followed by an application reset so the firmware boots automatically.
 - Use [tools/flash/recover.sh](tools/flash/recover.sh) if the board needs a full recover before reflashing.
 - Keep the device powered through USB or a sufficiently charged battery during flashing and recovery.
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@
    # --hw version is optional and can only be used with --left or --right
    ./tools/flash/flash_fota.sh --snr 123456789 --left --hw 2.0.1    
    ```
+   - After flashing, the script resets the complete device and starts the application automatically. A reset failure stops the script and returns an error.
 
    - or without FOTA
    ```bash
@@ -192,7 +193,6 @@ If you are using OpenEarable, please cite is as follows:
      publisher={ACM New York, NY, USA}
 }
 ```
-
 
 
 

--- a/tools/flash/flash_fota.ps1
+++ b/tools/flash/flash_fota.ps1
@@ -157,8 +157,17 @@ if ($Hw) {
 }
 
 # --- Reset ---
+# Reset the complete SoC first, then issue an application soft reset. The
+# application uses the resulting SREQ reset reason as a power-on request.
 Write-Host "Resetting device..."
-& nrfjprog --reset --family $Chip --snr $Snr --clockspeed $Clockspeed
+& nrfjprog --pinreset --family $Chip --snr $Snr --clockspeed $Clockspeed
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-Write-Host "`nDone." -ForegroundColor Green
+# Allow the bootloader and application to finish handling the pin reset before
+# setting the SREQ reset reason used by PowerManager.
+Start-Sleep -Seconds 5
+
+& nrfjprog --reset --family $Chip --coprocessor CP_APPLICATION --snr $Snr --clockspeed $Clockspeed
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+Write-Host "`nDone. Device reset; application is starting." -ForegroundColor Green

--- a/tools/flash/flash_fota.sh
+++ b/tools/flash/flash_fota.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Stop immediately if flashing or either reset operation fails.
+set -e
+
 # Default parameters
 CLOCKSPEED=8000
 CHIP=NRF53
@@ -115,5 +118,14 @@ if [ -n "$HW_VERSION" ]; then
     echo "Hardware version set to $HW_VERSION"
 fi
 
-# Reset device
-nrfjprog --reset -f $CHIP --snr $SNR --clockspeed $CLOCKSPEED
+# Reset the complete SoC, then issue an application soft reset. The pin reset
+# gives both nRF5340 cores and peripherals a clean start. The following soft
+# reset sets SREQ, which the application treats as an explicit power-on request.
+echo "Resetting device..."
+nrfjprog --pinreset -f $CHIP --snr $SNR --clockspeed $CLOCKSPEED
+# Allow the bootloader and application to finish handling the pin reset before
+# setting the SREQ reset reason used by PowerManager. Resetting during MCUboot
+# can cause that reason to be consumed before the application reads it.
+sleep 5
+nrfjprog --reset -f $CHIP --coprocessor CP_APPLICATION --snr $SNR --clockspeed $CLOCKSPEED
+echo "Device reset; application is starting."


### PR DESCRIPTION
## Summary

- stop the Bash FOTA flash script immediately when a programming or reset command fails
- perform a full pin reset after programming both nRF5340 cores
- wait for MCUboot and the application to handle the pin reset before issuing an application-core soft reset
- keep the Bash and PowerShell flashing flows and contributor documentation aligned

## Testing

- validated the Bash script syntax
- flashed and verified both cores on OpenEarable hardware
- confirmed over UART that the application received the software-reset power-on condition
- confirmed Bluetooth advertising and scanning started without a manual button reset