### PR TITLE
Fix battery charger fault decoding

### DIFF
--- a/tools/battery/README.md
+++ b/tools/battery/README.md
@@ -59,6 +59,17 @@ python3 tools/battery/battery_debug.py status --snr [YOUR_JLINK_SERIAL_NUMBER]
 This prints voltage, charger state, charger fault bits, power-good state, charge
 enable/high-Z state, temperature, state of charge, and related raw registers.
 
+The charger status register has a few latched bits that are easy to confuse:
+
+- `timer_fault=True` means the BQ25120A safety timer expired. This is reported
+  in the status register, so `charger_fault=0x00` can still be valid.
+- `reset_fault=True` is the separate reset-event latch. It may be set while the
+  charger is still actively charging.
+- `charger_ctrl=0x51` decodes as charging with `reset_fault=True` and
+  `timer_fault=False`.
+- `charger_ctrl=0xd9` decodes as charger fault with `timer_fault=True`; recovery
+  should clear it by toggling `CD` and reconfiguring the charger.
+
 ## Low-Battery Recovery
 
 Configure charging if the battery is below the start threshold:
@@ -80,6 +91,11 @@ Monitor continuously and reset the charger again if it enters fault:
 python3 tools/battery/battery_debug.py recover --snr [YOUR_JLINK_SERIAL_NUMBER] --continuous --reset-on-fault
 ```
 
+During recovery, safety-timer faults are reset even without `--reset-on-fault`.
+The reset sequence toggles the charger `CD` pin, then restores the charger
+configuration. If the reset limit is reached, the tool prints a warning instead
+of silently continuing with charging stopped.
+
 ## Useful Options
 
 - `--speed-khz 1000`: SWD speed.
@@ -87,6 +103,7 @@ python3 tools/battery/battery_debug.py recover --snr [YOUR_JLINK_SERIAL_NUMBER] 
 - `--start-below-mv 3000`: recovery starts below this voltage.
 - `--target-mv 3300`: recovery exits after reaching this voltage unless
   `--continuous` is set.
+- `--max-fault-resets 3`: maximum automatic charger resets during monitoring.
 - `--allow-deep-discharge`: allow recovery below the safety threshold. Use only
   with physical supervision.
 

--- a/tools/battery/README.md
+++ b/tools/battery/README.md
@@ -56,8 +56,9 @@ Read fuel-gauge and charger state:
 python3 tools/battery/battery_debug.py status --snr [YOUR_JLINK_SERIAL_NUMBER]
 ```
 
-This prints voltage, charger state, charger fault bits, power-good state, charge
-enable/high-Z state, temperature, state of charge, and related raw registers.
+This prints voltage, charger state, decoded charger and temperature faults,
+power-good state, charge enable/high-Z state, temperature, state of charge, and
+related raw registers.
 
 The charger status register has a few latched bits that are easy to confuse:
 
@@ -70,6 +71,10 @@ The charger status register has a few latched bits that are easy to confuse:
 - `charger_ctrl=0xd9` decodes as charger fault with `timer_fault=True`; recovery
   should clear it by toggling `CD` and reconfiguring the charger.
 
+The tool also names `VIN_OV`, `VIN_UV`, `BAT_UVLO`, `BAT_OCP`, VINDPM, and the
+three charger temperature states. `ts_fault=0x88` means charger-side temperature
+monitoring is enabled and currently normal; it is not a temperature fault.
+
 ## Low-Battery Recovery
 
 Configure charging if the battery is below the start threshold:
@@ -77,6 +82,17 @@ Configure charging if the battery is below the start threshold:
 ```bash
 python3 tools/battery/battery_debug.py recover --snr [YOUR_JLINK_SERIAL_NUMBER]
 ```
+
+For automatic recovery of resettable charger faults, use:
+
+```bash
+python3 tools/battery/battery_debug.py recover --snr [YOUR_JLINK_SERIAL_NUMBER] --reset-on-fault
+```
+
+The application core remains halted while recovery is running. Recovery exits
+after the battery reaches `--target-mv` (3300 mV by default) with no blocking
+fault, then verifies that the application core resumed. It also stops if the
+voltage fails to rise by at least 10 mV within 10 minutes by default.
 
 Force charger reset/configuration even if the voltage is already above the
 threshold:
@@ -92,9 +108,17 @@ python3 tools/battery/battery_debug.py recover --snr [YOUR_JLINK_SERIAL_NUMBER] 
 ```
 
 During recovery, safety-timer faults are reset even without `--reset-on-fault`.
-The reset sequence toggles the charger `CD` pin, then restores the charger
-configuration. If the reset limit is reached, the tool prints a warning instead
-of silently continuing with charging stopped.
+The reset sequence pulses the charger `CD` pin, verifies that it moved high and
+back low, resets the charger registers, restores the charger configuration, and
+checks that the timer fault cleared. A failed sequence is retried once. If a
+fault returns until `--max-fault-resets` is reached, recovery stops with an
+error instead of silently continuing with charging stopped.
+
+`BAT_UVLO`, VINDPM, and the cool/warm temperature derating states do not trigger
+repeated resets; recovery monitors them while voltage progresses. Missing input
+power, input overvoltage, battery overcurrent, and a hot/cold temperature
+suspension stop recovery immediately because software cannot safely clear the
+underlying electrical condition.
 
 ## Useful Options
 
@@ -104,6 +128,9 @@ of silently continuing with charging stopped.
 - `--target-mv 3300`: recovery exits after reaching this voltage unless
   `--continuous` is set.
 - `--max-fault-resets 3`: maximum automatic charger resets during monitoring.
+- `--stall-minutes 10`: stop after this long without meaningful voltage
+  progress; use `0` to disable.
+- `--stall-min-rise-mv 10`: voltage increase that resets the stall timer.
 - `--allow-deep-discharge`: allow recovery below the safety threshold. Use only
   with physical supervision.
 
@@ -112,5 +139,15 @@ of silently continuing with charging stopped.
 - Reading voltage/status is non-destructive apart from briefly halting the CPU.
 - Recovery writes charger registers and drives the charger `CD` pin low to allow
   charging.
+- `--continuous` keeps the application core halted and continues monitoring
+  after the target voltage; stop the command to resume the firmware.
 - If SWD cannot connect, the battery may still be too low or the target may not
   have enough power for debug access.
+
+## Tests
+
+Run the battery-tool tests without connecting hardware:
+
+```bash
+python3 -m unittest discover -s tools/battery -p 'test_*.py' -v
+```

--- a/tools/battery/README.md
+++ b/tools/battery/README.md
@@ -94,6 +94,9 @@ after the battery reaches `--target-mv` (3300 mV by default) with no blocking
 fault, then verifies that the application core resumed. It also stops if the
 voltage fails to rise by at least 10 mV within 10 minutes by default.
 
+Pressing Ctrl-C performs the same probe cleanup and resumes the application core
+unless `--no-resume` was specified.
+
 Force charger reset/configuration even if the voltage is already above the
 threshold:
 
@@ -123,6 +126,8 @@ underlying electrical condition.
 ## Useful Options
 
 - `--speed-khz 1000`: SWD speed.
+- `--interval-s 10`: status polling interval. Values above 30 seconds are
+  rejected so the BQ25120A's 50-second host watchdog remains serviced.
 - `--no-resume`: leave the app core halted after the operation.
 - `--start-below-mv 3000`: recovery starts below this voltage.
 - `--target-mv 3300`: recovery exits after reaching this voltage unless
@@ -143,6 +148,9 @@ underlying electrical condition.
   after the target voltage; stop the command to resume the firmware.
 - If SWD cannot connect, the battery may still be too low or the target may not
   have enough power for debug access.
+- TWIM errors identify address/data NACKs. A timeout reports the live SCL/SDA
+  levels so a stuck-low bus can be distinguished from an unresponsive battery
+  IC.
 
 ## Tests
 

--- a/tools/battery/battery_debug.py
+++ b/tools/battery/battery_debug.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import argparse
 import contextlib
 import dataclasses
+import math
 import sys
 import time
 from typing import Iterable
@@ -32,6 +33,7 @@ TWIM1 = 0x50009000
 GPIO0 = 0x50842500
 SCRATCH_TX = 0x20070000
 SCRATCH_RX = 0x20070080
+SCRATCH_BUFFER_SIZE = SCRATCH_RX - SCRATCH_TX
 
 SDA_PIN = 21
 SCL_PIN = 24
@@ -78,6 +80,10 @@ EVENTS_LASTTX = 0x160
 SHORT_LASTTX_STARTRX = 1 << 7
 SHORT_LASTTX_STOP = 1 << 8
 SHORT_LASTRX_STOP = 1 << 12
+
+TWIM_ERROR_OVERRUN = 1 << 0
+TWIM_ERROR_ANACK = 1 << 1
+TWIM_ERROR_DNACK = 1 << 2
 
 
 class BatteryDebugError(RuntimeError):
@@ -144,6 +150,22 @@ def u16le(data: Iterable[int]) -> int:
 def i16le(data: Iterable[int]) -> int:
     raw = bytes(data)
     return int.from_bytes(raw[:2], "little", signed=True)
+
+
+def describe_twim_error(error_source: int) -> str:
+    reasons = []
+    if error_source & TWIM_ERROR_OVERRUN:
+        reasons.append("EasyDMA overrun")
+    if error_source & TWIM_ERROR_ANACK:
+        reasons.append("address NACK")
+    if error_source & TWIM_ERROR_DNACK:
+        reasons.append("data NACK")
+    unknown = error_source & ~(
+        TWIM_ERROR_OVERRUN | TWIM_ERROR_ANACK | TWIM_ERROR_DNACK
+    )
+    if unknown:
+        reasons.append(f"unknown bits 0x{unknown:08x}")
+    return "+".join(reasons) if reasons else "no error source reported"
 
 
 def pin_cnf(pin: int) -> int:
@@ -280,45 +302,67 @@ class ChargerStatus:
 class JLinkBatteryInterface:
     def __init__(
         self,
-        snr: str | None,
+        snr: int | str | None,
         speed_khz: int,
         resume: bool = True,
         reset_target: bool = False,
     ):
-        self.snr = int(snr) if snr else None
+        self.snr = int(snr) if snr is not None else None
         self.speed_khz = speed_khz
         self.resume = resume
         self.reset_target = reset_target
         self.jlink = pylink.JLink()
         self.was_halted = False
+        self.probe_open = False
+        self.target_connected = False
+        self.resume_on_exit = False
 
     def __enter__(self) -> "JLinkBatteryInterface":
-        with self.jlink_operation(f"open probe {self.probe_description()}"):
-            self.jlink.open(serial_no=self.snr)
-        with self.jlink_operation("select SWD interface"):
-            self.jlink.set_tif(JLinkInterfaces.SWD)
-        with self.jlink_operation(
-            f"connect to {APP_CORE_DEVICE} at {self.speed_khz} kHz"
-        ):
-            self.jlink.connect(APP_CORE_DEVICE, speed=self.speed_khz, verbose=False)
-        if self.reset_target:
-            self.reset_and_halt_target()
-            self.was_halted = False
-        else:
-            with self.jlink_operation("read target halt state"):
-                self.was_halted = bool(self.jlink.halted())
-        if not self.was_halted and not self.reset_target:
-            with self.jlink_operation("halt target"):
-                self.jlink.halt()
-        self.setup_gpio()
-        self.setup_twim()
-        return self
+        try:
+            with self.jlink_operation(f"open probe {self.probe_description()}"):
+                self.jlink.open(serial_no=self.snr)
+            self.probe_open = True
+            with self.jlink_operation("select SWD interface"):
+                self.jlink.set_tif(JLinkInterfaces.SWD)
+            with self.jlink_operation(
+                f"connect to {APP_CORE_DEVICE} at {self.speed_khz} kHz"
+            ):
+                self.jlink.connect(APP_CORE_DEVICE, speed=self.speed_khz, verbose=False)
+            self.target_connected = True
+            if self.reset_target:
+                self.resume_on_exit = True
+                self.reset_and_halt_target()
+                self.was_halted = False
+            else:
+                with self.jlink_operation("read target halt state"):
+                    self.was_halted = bool(self.jlink.halted())
+                if not self.was_halted:
+                    self.resume_on_exit = True
+                    with self.jlink_operation("halt target"):
+                        self.jlink.halt()
+            self.setup_gpio()
+            self.setup_twim()
+            return self
+        except BaseException:
+            self.cleanup_after_enter_failure()
+            raise
+
+    def cleanup_after_enter_failure(self) -> None:
+        if self.target_connected:
+            with contextlib.suppress(Exception):
+                self.w32(TWIM1 + TWIM_ENABLE, 0)
+        if self.resume and self.resume_on_exit:
+            with contextlib.suppress(Exception):
+                self.resume_target()
+        with contextlib.suppress(Exception):
+            self.jlink.close()
+        self.probe_open = False
 
     def __exit__(self, exc_type, exc, tb) -> None:
         resume_error = None
         with contextlib.suppress(Exception):
             self.w32(TWIM1 + TWIM_ENABLE, 0)
-        if self.resume and not self.was_halted:
+        if self.resume and self.resume_on_exit:
             try:
                 self.resume_target()
             except Exception as restart_exc:
@@ -329,8 +373,10 @@ class JLinkBatteryInterface:
                         f"warning: failed to resume application core: {restart_exc}",
                         file=sys.stderr,
                     )
-        with contextlib.suppress(Exception):
-            self.jlink.close()
+        if self.probe_open:
+            with contextlib.suppress(Exception):
+                self.jlink.close()
+            self.probe_open = False
         if resume_error is not None:
             raise resume_error
 
@@ -366,7 +412,12 @@ class JLinkBatteryInterface:
 
     def r32(self, addr: int) -> int:
         with self.jlink_operation(f"read 32-bit word at 0x{addr:08x}"):
-            return self.jlink.memory_read32(addr, 1)[0]
+            values = self.jlink.memory_read32(addr, 1)
+        if len(values) != 1:
+            raise BatteryDebugError(
+                f"J-Link returned {len(values)} words while reading 0x{addr:08x}; expected 1"
+            )
+        return values[0]
 
     def w32(self, addr: int, value: int) -> None:
         with self.jlink_operation(f"write 32-bit word at 0x{addr:08x}"):
@@ -374,7 +425,13 @@ class JLinkBatteryInterface:
 
     def r8(self, addr: int, count: int) -> list[int]:
         with self.jlink_operation(f"read {count} byte(s) at 0x{addr:08x}"):
-            return list(self.jlink.memory_read8(addr, count))
+            values = list(self.jlink.memory_read8(addr, count))
+        if len(values) != count:
+            raise BatteryDebugError(
+                f"J-Link returned {len(values)} byte(s) while reading 0x{addr:08x}; "
+                f"expected {count}"
+            )
+        return values
 
     def w8(self, addr: int, data: Iterable[int]) -> None:
         payload = list(data)
@@ -403,23 +460,52 @@ class JLinkBatteryInterface:
     def wait_twim(self, timeout_s: float = 0.050) -> None:
         deadline = time.monotonic() + timeout_s
         while time.monotonic() < deadline:
-            if self.r32(TWIM1 + EVENTS_STOPPED):
-                return
             if self.r32(TWIM1 + EVENTS_ERROR):
                 err = self.r32(TWIM1 + TWIM_ERRORSRC)
                 amount_tx = self.r32(TWIM1 + TWIM_TXD_AMOUNT)
                 amount_rx = self.r32(TWIM1 + TWIM_RXD_AMOUNT)
+                stopped = self.stop_twim()
                 raise BatteryDebugError(
-                    f"TWIM error errsrc=0x{err:08x} tx_amount={amount_tx} rx_amount={amount_rx}"
+                    f"TWIM error ({describe_twim_error(err)}; "
+                    f"errsrc=0x{err:08x}, tx_amount={amount_tx}, "
+                    f"rx_amount={amount_rx}, stop={'ok' if stopped else 'timed out'})"
                 )
+            if self.r32(TWIM1 + EVENTS_STOPPED):
+                return
             time.sleep(0.001)
+        stopped = self.stop_twim()
+        err = self.r32(TWIM1 + TWIM_ERRORSRC)
+        amount_tx = self.r32(TWIM1 + TWIM_TXD_AMOUNT)
+        amount_rx = self.r32(TWIM1 + TWIM_RXD_AMOUNT)
+        gpio_in = self.raw_gpio0_in()
+        scl = "high" if gpio_in & (1 << SCL_PIN) else "low"
+        sda = "high" if gpio_in & (1 << SDA_PIN) else "low"
+        raise BatteryDebugError(
+            f"TWIM transaction timed out after {timeout_s * 1000:g} ms "
+            f"(SCL={scl}, SDA={sda}, {describe_twim_error(err)}, "
+            f"tx_amount={amount_tx}, rx_amount={amount_rx}, "
+            f"stop={'ok' if stopped else 'timed out'}). "
+            "A low SCL/SDA level indicates a stuck I2C bus; high lines usually "
+            "mean the addressed battery IC is not responding."
+        )
+
+    def stop_twim(self, timeout_s: float = 0.010) -> bool:
         self.w32(TWIM1 + TASKS_STOP, 1)
-        raise BatteryDebugError("TWIM transaction timed out")
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            if self.r32(TWIM1 + EVENTS_STOPPED):
+                return True
+            time.sleep(0.001)
+        return False
 
     def i2c_write(self, addr: int, data: Iterable[int]) -> None:
         payload = bytes(data)
         if not payload:
             raise ValueError("i2c_write payload must not be empty")
+        if len(payload) > SCRATCH_BUFFER_SIZE:
+            raise ValueError(
+                f"i2c_write payload exceeds {SCRATCH_BUFFER_SIZE}-byte scratch buffer"
+            )
         self.setup_twim()
         self.w8(SCRATCH_TX, payload)
         self.clear_twim_events()
@@ -429,20 +515,25 @@ class JLinkBatteryInterface:
         self.w32(TWIM1 + TWIM_RXD_PTR, SCRATCH_RX)
         self.w32(TWIM1 + TWIM_RXD_MAXCNT, 0)
         self.w32(TWIM1 + TWIM_SHORTS, SHORT_LASTTX_STOP)
-        self.w32(TWIM1 + TASKS_STARTTX, 1)
-        self.wait_twim()
-        sent = self.r32(TWIM1 + TWIM_TXD_AMOUNT)
-        self.w32(TWIM1 + TWIM_SHORTS, 0)
+        try:
+            self.w32(TWIM1 + TASKS_STARTTX, 1)
+            self.wait_twim()
+            sent = self.r32(TWIM1 + TWIM_TXD_AMOUNT)
+        finally:
+            self.w32(TWIM1 + TWIM_SHORTS, 0)
         if sent != len(payload):
             raise BatteryDebugError(f"short I2C write to 0x{addr:02x}: sent {sent}/{len(payload)}")
 
     def i2c_read_reg(self, addr: int, reg: int, count: int) -> list[int]:
         if count <= 0:
             raise ValueError("read count must be positive")
+        if count > SCRATCH_BUFFER_SIZE:
+            raise ValueError(
+                f"read count exceeds {SCRATCH_BUFFER_SIZE}-byte scratch buffer"
+            )
         self.setup_twim()
-        sentinel = [((0xA5 ^ addr ^ reg ^ i) & 0xFF) for i in range(count)]
         self.w8(SCRATCH_TX, [reg & 0xFF])
-        self.w8(SCRATCH_RX, sentinel)
+        self.w8(SCRATCH_RX, [0] * count)
         self.clear_twim_events()
         self.w32(TWIM1 + TWIM_ADDRESS, addr)
         self.w32(TWIM1 + TWIM_TXD_PTR, SCRATCH_TX)
@@ -450,19 +541,21 @@ class JLinkBatteryInterface:
         self.w32(TWIM1 + TWIM_RXD_PTR, SCRATCH_RX)
         self.w32(TWIM1 + TWIM_RXD_MAXCNT, count)
         self.w32(TWIM1 + TWIM_SHORTS, SHORT_LASTTX_STARTRX | SHORT_LASTRX_STOP)
-        self.w32(TWIM1 + TASKS_STARTTX, 1)
-        self.wait_twim()
-        rx_amount = self.r32(TWIM1 + TWIM_RXD_AMOUNT)
-        self.w32(TWIM1 + TWIM_SHORTS, 0)
+        try:
+            self.w32(TWIM1 + TASKS_STARTTX, 1)
+            self.wait_twim()
+            rx_amount = self.r32(TWIM1 + TWIM_RXD_AMOUNT)
+            last_rx = self.r32(TWIM1 + EVENTS_LASTRX)
+        finally:
+            self.w32(TWIM1 + TWIM_SHORTS, 0)
+        if not last_rx:
+            raise BatteryDebugError(
+                f"I2C read from 0x{addr:02x} register 0x{reg:02x} did not "
+                "signal LASTRX"
+            )
         if rx_amount != count:
             raise BatteryDebugError(f"short I2C read from 0x{addr:02x}: got {rx_amount}/{count}")
-        data = self.r8(SCRATCH_RX, count)
-        if data == sentinel:
-            raise BatteryDebugError(
-                f"I2C read from 0x{addr:02x} register 0x{reg:02x} did not update "
-                "the RX buffer; refusing to use stale scratch RAM"
-            )
-        return data
+        return self.r8(SCRATCH_RX, count)
 
     def bq27220_u16(self, reg: int) -> int:
         try:
@@ -589,8 +682,8 @@ class JLinkBatteryInterface:
 
     def reset_charger(self) -> None:
         # The BQ25120A safety-timer latch is cleared by toggling CD or power.
-        self.set_cd(1)
         try:
+            self.set_cd(1)
             if not (self.raw_gpio0_in() & (1 << CD_PIN)):
                 raise BatteryDebugError("charger CD pin did not go high")
             time.sleep(0.020)
@@ -678,9 +771,62 @@ def format_status(fuel: FuelGaugeStatus, charger: ChargerStatus) -> str:
     return ", ".join(fields)
 
 
+def positive_int_arg(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be an integer") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be greater than zero")
+    return parsed
+
+
+def nonnegative_int_arg(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be an integer") from exc
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be zero or greater")
+    return parsed
+
+
+def positive_float_arg(value: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a number") from exc
+    if not math.isfinite(parsed) or parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a finite number greater than zero")
+    return parsed
+
+
+def nonnegative_float_arg(value: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a number") from exc
+    if not math.isfinite(parsed) or parsed < 0:
+        raise argparse.ArgumentTypeError("must be a finite number zero or greater")
+    return parsed
+
+
+def monitoring_interval_arg(value: str) -> float:
+    parsed = positive_float_arg(value)
+    if parsed > 30:
+        raise argparse.ArgumentTypeError(
+            "must be 30 seconds or less to service the charger's watchdog"
+        )
+    return parsed
+
+
 def add_common_args(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument("--snr", help="J-Link serial number, for example 261010806")
-    parser.add_argument("--speed-khz", type=int, default=DEFAULT_SPEED_KHZ)
+    parser.add_argument(
+        "--snr",
+        type=positive_int_arg,
+        help="J-Link serial number, for example 261010806",
+    )
+    parser.add_argument("--speed-khz", type=positive_int_arg, default=DEFAULT_SPEED_KHZ)
     reset_group = parser.add_mutually_exclusive_group()
     reset_group.add_argument(
         "--reset-target",
@@ -781,6 +927,13 @@ def reset_and_configure_charger(
             if not charger.sys_enabled:
                 raise BatteryDebugError(
                     "charger system output remained disabled after reset"
+                )
+            expected_charge_ctrl = encode_charge_current(args.charge_current_ma)
+            if charger.charge_ctrl != expected_charge_ctrl:
+                raise BatteryDebugError(
+                    "charger current configuration did not stick: "
+                    f"read 0x{charger.charge_ctrl:02x}, expected "
+                    f"0x{expected_charge_ctrl:02x}"
                 )
             return charger
         except BatteryDebugError as exc:
@@ -899,10 +1052,24 @@ def cmd_recover(args: argparse.Namespace) -> int:
                 )
                 return 1
 
+            if reset_reason is None and fuel.voltage_mv >= args.target_mv and not args.continuous:
+                if args.no_resume:
+                    action = "Leaving the application core halted (--no-resume)."
+                else:
+                    action = "Restarting the application core."
+                print(
+                    f"Target reached with no blocking charger fault: "
+                    f"{fuel.voltage_mv} mV >= {args.target_mv} mV. {action}"
+                )
+                return 0
+
+            now = time.monotonic()
+            if args.max_minutes and (now - started) > args.max_minutes * 60:
+                print("Recovery monitoring timed out.", file=sys.stderr)
+                return 1
+
             if reset_reason:
-                cooldown_ok = (
-                    time.monotonic() - last_reset
-                ) >= args.fault_reset_cooldown_s
+                cooldown_ok = (now - last_reset) >= args.fault_reset_cooldown_s
                 if cooldown_ok:
                     if reset_count >= args.max_fault_resets:
                         print(
@@ -932,18 +1099,7 @@ def cmd_recover(args: argparse.Namespace) -> int:
                 time.sleep(args.interval_s)
                 continue
 
-            if fuel.voltage_mv >= args.target_mv and not args.continuous:
-                print(
-                    f"Target reached with no blocking charger fault: "
-                    f"{fuel.voltage_mv} mV >= {args.target_mv} mV. "
-                    "Restarting the application core."
-                )
-                return 0
-
-            if args.max_minutes and (time.monotonic() - started) > args.max_minutes * 60:
-                print("Recovery monitoring timed out.", file=sys.stderr)
-                return 1
-
+            progress_voltage_mv = min(progress_voltage_mv, fuel.voltage_mv)
             if fuel.voltage_mv >= progress_voltage_mv + args.stall_min_rise_mv:
                 progress_started = time.monotonic()
                 progress_voltage_mv = fuel.voltage_mv
@@ -990,30 +1146,39 @@ def build_parser() -> argparse.ArgumentParser:
         "recover", help="Configure/reset charging and optionally monitor progress."
     )
     add_common_args(recover)
-    recover.add_argument("--start-below-mv", type=int, default=3000)
-    recover.add_argument("--target-mv", type=int, default=3300)
-    recover.add_argument("--min-safe-mv", type=int, default=2500)
-    recover.add_argument("--charge-current-ma", type=int, default=110)
-    recover.add_argument("--termination-current-ma", type=float, default=10.0)
-    recover.add_argument("--target-voltage-mv", type=int, default=4300)
-    recover.add_argument("--input-limit-ma", type=int, default=200)
-    recover.add_argument("--uvlo-mv", type=int, default=2500)
-    recover.add_argument("--interval-s", type=float, default=10.0)
-    recover.add_argument("--max-minutes", type=float, default=0.0)
+    recover.add_argument("--start-below-mv", type=positive_int_arg, default=3000)
+    recover.add_argument("--target-mv", type=positive_int_arg, default=3300)
+    recover.add_argument("--min-safe-mv", type=positive_int_arg, default=2500)
+    recover.add_argument("--charge-current-ma", type=positive_int_arg, default=110)
+    recover.add_argument(
+        "--termination-current-ma", type=positive_float_arg, default=10.0
+    )
+    recover.add_argument("--target-voltage-mv", type=positive_int_arg, default=4300)
+    recover.add_argument("--input-limit-ma", type=positive_int_arg, default=200)
+    recover.add_argument("--uvlo-mv", type=positive_int_arg, default=2500)
+    recover.add_argument("--interval-s", type=monitoring_interval_arg, default=10.0)
+    recover.add_argument("--max-minutes", type=nonnegative_float_arg, default=0.0)
     recover.add_argument(
         "--stall-minutes",
-        type=float,
+        type=nonnegative_float_arg,
         default=10.0,
         help="Stop if voltage makes no meaningful progress for this long; 0 disables.",
     )
     recover.add_argument(
         "--stall-min-rise-mv",
-        type=int,
+        type=positive_int_arg,
         default=10,
         help="Voltage rise that resets the stall timer.",
     )
-    recover.add_argument("--max-fault-resets", "--max-timer-resets", type=int, default=3)
-    recover.add_argument("--fault-reset-cooldown-s", type=float, default=30.0)
+    recover.add_argument(
+        "--max-fault-resets",
+        "--max-timer-resets",
+        type=nonnegative_int_arg,
+        default=3,
+    )
+    recover.add_argument(
+        "--fault-reset-cooldown-s", type=nonnegative_float_arg, default=30.0
+    )
     recover.add_argument("--continuous", action="store_true")
     recover.add_argument("--reset-on-fault", action="store_true")
     recover.add_argument("--force", action="store_true")
@@ -1039,11 +1204,21 @@ def main(argv: list[str] | None = None) -> int:
         return 2
     try:
         return args.func(args)
+    except KeyboardInterrupt:
+        print("battery_debug: interrupted.", file=sys.stderr)
+        return 130
     except BatteryDebugError as exc:
         print(f"battery_debug: {exc}", file=sys.stderr)
         return 1
     except pylink.errors.JLinkException as exc:
         print(f"battery_debug: {format_jlink_failure('operation', exc)}", file=sys.stderr)
+        return 1
+    except OSError as exc:
+        print(
+            f"battery_debug: operating-system error: {exc}. Check that J-Link "
+            "software 8.82 is installed and the probe is available.",
+            file=sys.stderr,
+        )
         return 1
 
 

--- a/tools/battery/battery_debug.py
+++ b/tools/battery/battery_debug.py
@@ -47,7 +47,11 @@ FREQUENCY_400K = 0x06400000
 
 GPIO_PIN_CNF_INPUT_PULLUP_S0D1 = 0x0000060C
 GPIO_PIN_CNF_INPUT_PULLUP = 0x0000000C
-GPIO_PIN_CNF_OUTPUT = 0x00000003
+GPIO_PIN_CNF_OUTPUT_WITH_INPUT = 0x00000001
+
+GPIO_OUTSET = 0x008
+GPIO_OUTCLR = 0x00C
+GPIO_IN = 0x010
 
 TWIM_ENABLE = 0x500
 TWIM_PSEL_SCL = 0x508
@@ -204,8 +208,16 @@ class ChargerStatus:
         reasons = []
         if self.timer_fault:
             reasons.append("safety_timer")
+        if self.vin_overvoltage:
+            reasons.append("VIN_OV")
+        if self.vin_undervoltage:
+            reasons.append("VIN_UV")
         if self.bat_uvlo:
             reasons.append("BAT_UVLO")
+        if self.battery_overcurrent:
+            reasons.append("BAT_OCP")
+        if self.ts_fault_code:
+            reasons.append(self.ts_state)
         if self.vindpm_active and self.charging_state_code == 3:
             reasons.append("VINDPM")
         if self.charging_state_code == 3 and not reasons:
@@ -213,8 +225,48 @@ class ChargerStatus:
         return reasons
 
     @property
+    def blocking_fault_reasons(self) -> list[str]:
+        reasons = []
+        if self.vin_overvoltage:
+            reasons.append("VIN_OV")
+        if self.battery_overcurrent:
+            reasons.append("BAT_OCP")
+        if self.ts_fault_code == 1:
+            reasons.append(self.ts_state)
+        return reasons
+
+    @property
+    def vin_overvoltage(self) -> bool:
+        return bool(self.fault & (1 << 7))
+
+    @property
+    def vin_undervoltage(self) -> bool:
+        return bool(self.fault & (1 << 6))
+
+    @property
     def bat_uvlo(self) -> bool:
         return bool(self.fault & (1 << 5))
+
+    @property
+    def battery_overcurrent(self) -> bool:
+        return bool(self.fault & (1 << 4))
+
+    @property
+    def ts_enabled(self) -> bool:
+        return bool(self.ts_fault & (1 << 7))
+
+    @property
+    def ts_fault_code(self) -> int:
+        return (self.ts_fault >> 5) & 0x03
+
+    @property
+    def ts_state(self) -> str:
+        return {
+            0: "TS_normal",
+            1: "TS_hot_or_cold",
+            2: "TS_cool_current_reduced",
+            3: "TS_warm_voltage_reduced",
+        }[self.ts_fault_code]
 
     @property
     def charge_enabled(self) -> bool:
@@ -263,13 +315,24 @@ class JLinkBatteryInterface:
         return self
 
     def __exit__(self, exc_type, exc, tb) -> None:
+        resume_error = None
         with contextlib.suppress(Exception):
             self.w32(TWIM1 + TWIM_ENABLE, 0)
         if self.resume and not self.was_halted:
-            with contextlib.suppress(Exception):
-                self.jlink.restart()
+            try:
+                self.resume_target()
+            except Exception as restart_exc:
+                if exc_type is None:
+                    resume_error = restart_exc
+                else:
+                    print(
+                        f"warning: failed to resume application core: {restart_exc}",
+                        file=sys.stderr,
+                    )
         with contextlib.suppress(Exception):
             self.jlink.close()
+        if resume_error is not None:
+            raise resume_error
 
     def probe_description(self) -> str:
         if self.snr is not None:
@@ -280,6 +343,13 @@ class JLinkBatteryInterface:
         with self.jlink_operation("reset and halt target"):
             self.jlink.reset(ms=10, halt=True)
         time.sleep(0.010)
+
+    def resume_target(self) -> None:
+        with self.jlink_operation("resume application core"):
+            self.jlink.restart()
+            time.sleep(0.010)
+            if self.jlink.halted():
+                raise BatteryDebugError("application core remained halted after restart")
 
     def recover_target_state(self) -> None:
         if self.reset_target:
@@ -315,7 +385,7 @@ class JLinkBatteryInterface:
         self.w32(pin_cnf(SDA_PIN), GPIO_PIN_CNF_INPUT_PULLUP_S0D1)
         self.w32(pin_cnf(SCL_PIN), GPIO_PIN_CNF_INPUT_PULLUP_S0D1)
         self.w32(pin_cnf(PG_PIN), GPIO_PIN_CNF_INPUT_PULLUP)
-        self.w32(pin_cnf(CD_PIN), GPIO_PIN_CNF_OUTPUT)
+        self.w32(pin_cnf(CD_PIN), GPIO_PIN_CNF_OUTPUT_WITH_INPUT)
 
     def setup_twim(self, frequency: int = FREQUENCY_400K) -> None:
         self.w32(TWIM1 + TWIM_ENABLE, 0)
@@ -423,13 +493,13 @@ class JLinkBatteryInterface:
             ) from exc
 
     def raw_gpio0_in(self) -> int:
-        return self.r32(GPIO0 + 0x10)
+        return self.r32(GPIO0 + GPIO_IN)
 
     def set_cd(self, raw_value: int) -> None:
         if raw_value:
-            self.w32(GPIO0 + 0x508, 1 << CD_PIN)  # OUTSET
+            self.w32(GPIO0 + GPIO_OUTSET, 1 << CD_PIN)
         else:
-            self.w32(GPIO0 + 0x50C, 1 << CD_PIN)  # OUTCLR
+            self.w32(GPIO0 + GPIO_OUTCLR, 1 << CD_PIN)
         time.sleep(0.001)
 
     def read_fuel_gauge(self, include_gauging_status: bool = False) -> FuelGaugeStatus:
@@ -493,11 +563,10 @@ class JLinkBatteryInterface:
     ) -> None:
         self.set_cd(0)
         writes = [
-            (0x02, 0x00, "clear TS fault bits"),
             (0x03, encode_charge_current(charge_current_ma), "set charge current"),
         ]
         if full_config:
-            writes[1:1] = [(0x05, encode_target_voltage(target_voltage_mv), "set target voltage")]
+            writes[0:0] = [(0x05, encode_target_voltage(target_voltage_mv), "set target voltage")]
             writes.extend(
                 [
                     (
@@ -516,18 +585,19 @@ class JLinkBatteryInterface:
             try:
                 self.bq25120a_write_u8(reg, value)
             except BatteryDebugError as exc:
-                print(
-                    f"warning: failed to {description}; continuing: {exc}",
-                    file=sys.stderr,
-                )
-                self.recover_target_state()
-                break
+                raise BatteryDebugError(f"failed to {description}: {exc}") from exc
 
     def reset_charger(self) -> None:
         # The BQ25120A safety-timer latch is cleared by toggling CD or power.
         self.set_cd(1)
-        time.sleep(0.020)
-        self.set_cd(0)
+        try:
+            if not (self.raw_gpio0_in() & (1 << CD_PIN)):
+                raise BatteryDebugError("charger CD pin did not go high")
+            time.sleep(0.020)
+        finally:
+            self.set_cd(0)
+        if self.raw_gpio0_in() & (1 << CD_PIN):
+            raise BatteryDebugError("charger CD pin did not return low")
         time.sleep(0.020)
         self.bq25120a_write_u8(0x09, 0x80)
         time.sleep(0.010)
@@ -577,6 +647,8 @@ def format_status(fuel: FuelGaugeStatus, charger: ChargerStatus) -> str:
         f"charge_enabled={charger.charge_enabled}",
         f"high_z={charger.high_z}",
         f"VINDPM={charger.vindpm_active}",
+        f"TS_enabled={charger.ts_enabled}",
+        f"TS_state={charger.ts_state}",
         f"CD_stat={charger.cd_stat}",
         f"SYS_enabled={charger.sys_enabled}",
         f"PG_present={charger.pg_present}",
@@ -639,23 +711,87 @@ def open_link(args: argparse.Namespace) -> JLinkBatteryInterface:
     )
 
 
-def try_reset_charger(link: JLinkBatteryInterface) -> None:
-    try:
-        link.reset_charger()
-    except BatteryDebugError as exc:
-        print(
-            f"warning: charger reset sequence failed; continuing with configuration: {exc}",
-            file=sys.stderr,
-        )
-        link.recover_target_state()
+def charger_blocking_reasons(charger: ChargerStatus) -> list[str]:
+    reasons = []
+    if not charger.pg_present:
+        reasons.append("input_power_missing")
+    reasons.extend(charger.blocking_fault_reasons)
+    return reasons
 
 
 def charger_recovery_reason(charger: ChargerStatus, reset_on_fault: bool) -> str | None:
     if charger.timer_fault:
         return "safety timer fault"
-    if reset_on_fault and charger.charging_state_code == 3 and not charger.bat_uvlo:
-        return "charger status fault"
+    if not reset_on_fault:
+        return None
+    if charger.cd_stat or charger.cd_raw:
+        return "charger disable pin is high"
+    if not charger.charge_enabled:
+        return "charging is disabled"
+    if charger.high_z:
+        return "charger is in high-impedance mode"
+    if not charger.sys_enabled:
+        return "charger system output is disabled"
+    known_nonblocking_fault = (
+        charger.bat_uvlo
+        or charger.vin_undervoltage
+        or charger.vindpm_active
+        or charger.ts_fault_code in (2, 3)
+    )
+    if (
+        charger.charging_state_code == 3
+        and not charger.blocking_fault_reasons
+        and not known_nonblocking_fault
+    ):
+        return "unclassified charger status fault"
     return None
+
+
+def reset_and_configure_charger(
+    link: JLinkBatteryInterface, args: argparse.Namespace
+) -> ChargerStatus:
+    last_error = None
+    for attempt in range(2):
+        try:
+            link.reset_charger()
+            link.configure_charger(
+                charge_current_ma=args.charge_current_ma,
+                termination_current_ma=args.termination_current_ma,
+                target_voltage_mv=args.target_voltage_mv,
+                input_limit_ma=args.input_limit_ma,
+                uvlo_mv=args.uvlo_mv,
+                full_config=args.full_charger_config,
+            )
+            time.sleep(0.050)
+            charger = link.read_charger()
+            if charger_blocking_reasons(charger):
+                return charger
+            if charger.timer_fault:
+                raise BatteryDebugError(
+                    "safety timer fault remained set after the CD pulse"
+                )
+            if charger.cd_stat or charger.cd_raw:
+                raise BatteryDebugError("charger CD pin remained high after reset")
+            if not charger.charge_enabled:
+                raise BatteryDebugError("charging remained disabled after configuration")
+            if charger.high_z:
+                raise BatteryDebugError(
+                    "charger remained in high-impedance mode after configuration"
+                )
+            if not charger.sys_enabled:
+                raise BatteryDebugError(
+                    "charger system output remained disabled after reset"
+                )
+            return charger
+        except BatteryDebugError as exc:
+            last_error = exc
+            if attempt == 0:
+                print(
+                    f"warning: charger recovery attempt failed; retrying once: {exc}",
+                    file=sys.stderr,
+                )
+                link.recover_target_state()
+    raise BatteryDebugError(f"charger recovery failed after two attempts: {last_error}")
 
 
 def cmd_voltage(args: argparse.Namespace) -> int:
@@ -682,6 +818,15 @@ def cmd_recover(args: argparse.Namespace) -> int:
         charger = link.read_charger()
         print("initial:", format_status(fuel, charger))
 
+        blockers = charger_blocking_reasons(charger)
+        if blockers:
+            print(
+                "Recovery cannot continue while blocking fault(s) are active: "
+                f"{'+'.join(blockers)}.",
+                file=sys.stderr,
+            )
+            return 1
+
         if fuel.voltage_mv < args.min_safe_mv and not args.allow_deep_discharge:
             print(
                 f"Refusing recovery below {args.min_safe_mv} mV without "
@@ -692,6 +837,7 @@ def cmd_recover(args: argparse.Namespace) -> int:
 
         needs_recovery = fuel.voltage_mv < args.start_below_mv or args.force
         reset_reason = charger_recovery_reason(charger, args.reset_on_fault)
+        available_reset = charger_recovery_reason(charger, True)
         if needs_recovery or reset_reason:
             if args.force:
                 reason = "forced"
@@ -700,15 +846,23 @@ def cmd_recover(args: argparse.Namespace) -> int:
             else:
                 reason = reset_reason
             print(f"resetting/configuring charger ({reason})")
-            try_reset_charger(link)
-            link.configure_charger(
-                charge_current_ma=args.charge_current_ma,
-                termination_current_ma=args.termination_current_ma,
-                target_voltage_mv=args.target_voltage_mv,
-                input_limit_ma=args.input_limit_ma,
-                uvlo_mv=args.uvlo_mv,
-                full_config=args.full_charger_config,
+            charger = reset_and_configure_charger(link, args)
+            print("after reset:", format_status(fuel, charger))
+            blockers = charger_blocking_reasons(charger)
+            if blockers:
+                print(
+                    "Recovery stopped because blocking fault(s) remained after "
+                    f"reset: {'+'.join(blockers)}.",
+                    file=sys.stderr,
+                )
+                return 1
+        elif available_reset:
+            print(
+                f"Recovery stopped: {available_reset}. Rerun with --reset-on-fault "
+                "to allow an automatic charger reset.",
+                file=sys.stderr,
             )
+            return 1
         elif not args.continuous:
             print(
                 f"Voltage is not below {args.start_below_mv} mV; no recovery needed. "
@@ -717,50 +871,94 @@ def cmd_recover(args: argparse.Namespace) -> int:
             return 0
 
         started = time.monotonic()
+        progress_started = started
+        progress_voltage_mv = fuel.voltage_mv
         reset_count = 0
         last_reset = 0.0
-        reset_limit_warned = False
         while True:
             fuel = link.read_fuel_gauge()
             charger = link.read_charger()
             print(time.strftime("%H:%M:%S"), format_status(fuel, charger), flush=True)
 
-            if fuel.voltage_mv >= args.target_mv and not args.continuous:
-                print(f"Target reached: {fuel.voltage_mv} mV >= {args.target_mv} mV")
-                return 0
-
-            if args.max_minutes and (time.monotonic() - started) > args.max_minutes * 60:
-                print("Timed out before reaching target voltage.", file=sys.stderr)
+            blockers = charger_blocking_reasons(charger)
+            if blockers:
+                print(
+                    "Recovery stopped because blocking fault(s) became active: "
+                    f"{'+'.join(blockers)}.",
+                    file=sys.stderr,
+                )
                 return 1
 
             reset_reason = charger_recovery_reason(charger, args.reset_on_fault)
-            cooldown_ok = (time.monotonic() - last_reset) >= args.fault_reset_cooldown_s
-            if reset_reason and cooldown_ok:
-                if reset_count < args.max_fault_resets:
+            available_reset = charger_recovery_reason(charger, True)
+            if available_reset and not reset_reason:
+                print(
+                    f"Recovery stopped: {available_reset}. Rerun with "
+                    "--reset-on-fault to allow an automatic charger reset.",
+                    file=sys.stderr,
+                )
+                return 1
+
+            if reset_reason:
+                cooldown_ok = (
+                    time.monotonic() - last_reset
+                ) >= args.fault_reset_cooldown_s
+                if cooldown_ok:
+                    if reset_count >= args.max_fault_resets:
+                        print(
+                            f"Recovery stopped: {reset_reason} is still present and "
+                            f"the reset limit ({args.max_fault_resets}) was reached.",
+                            file=sys.stderr,
+                        )
+                        return 1
                     reset_count += 1
                     last_reset = time.monotonic()
-                    reset_limit_warned = False
                     print(
-                        f"{reset_reason} seen; reset {reset_count}/{args.max_fault_resets}"
+                        f"{reset_reason} seen; reset "
+                        f"{reset_count}/{args.max_fault_resets}"
                     )
-                    try_reset_charger(link)
-                    link.configure_charger(
-                        charge_current_ma=args.charge_current_ma,
-                        termination_current_ma=args.termination_current_ma,
-                        target_voltage_mv=args.target_voltage_mv,
-                        input_limit_ma=args.input_limit_ma,
-                        uvlo_mv=args.uvlo_mv,
-                        full_config=args.full_charger_config,
-                    )
-                elif not reset_limit_warned:
-                    print(
-                        f"warning: {reset_reason} still present but reset limit "
-                        f"({args.max_fault_resets}) has been reached. Check the "
-                        "device temperature, then rerun recovery or increase "
-                        "--max-fault-resets if continued supervised recovery is needed.",
-                        file=sys.stderr,
-                    )
-                    reset_limit_warned = True
+                    charger = reset_and_configure_charger(link, args)
+                    print("after reset:", format_status(fuel, charger))
+                    blockers = charger_blocking_reasons(charger)
+                    if blockers:
+                        print(
+                            "Recovery stopped because blocking fault(s) remained "
+                            f"after reset: {'+'.join(blockers)}.",
+                            file=sys.stderr,
+                        )
+                        return 1
+                    progress_started = time.monotonic()
+                    progress_voltage_mv = fuel.voltage_mv
+                time.sleep(args.interval_s)
+                continue
+
+            if fuel.voltage_mv >= args.target_mv and not args.continuous:
+                print(
+                    f"Target reached with no blocking charger fault: "
+                    f"{fuel.voltage_mv} mV >= {args.target_mv} mV. "
+                    "Restarting the application core."
+                )
+                return 0
+
+            if args.max_minutes and (time.monotonic() - started) > args.max_minutes * 60:
+                print("Recovery monitoring timed out.", file=sys.stderr)
+                return 1
+
+            if fuel.voltage_mv >= progress_voltage_mv + args.stall_min_rise_mv:
+                progress_started = time.monotonic()
+                progress_voltage_mv = fuel.voltage_mv
+            elif (
+                args.stall_minutes
+                and fuel.voltage_mv < args.target_mv
+                and (time.monotonic() - progress_started) > args.stall_minutes * 60
+            ):
+                print(
+                    "Recovery stalled: voltage did not rise by at least "
+                    f"{args.stall_min_rise_mv} mV within {args.stall_minutes:g} "
+                    "minute(s). Check the USB supply, battery, and device temperature.",
+                    file=sys.stderr,
+                )
+                return 1
 
             time.sleep(args.interval_s)
 
@@ -802,6 +1000,18 @@ def build_parser() -> argparse.ArgumentParser:
     recover.add_argument("--uvlo-mv", type=int, default=2500)
     recover.add_argument("--interval-s", type=float, default=10.0)
     recover.add_argument("--max-minutes", type=float, default=0.0)
+    recover.add_argument(
+        "--stall-minutes",
+        type=float,
+        default=10.0,
+        help="Stop if voltage makes no meaningful progress for this long; 0 disables.",
+    )
+    recover.add_argument(
+        "--stall-min-rise-mv",
+        type=int,
+        default=10,
+        help="Voltage rise that resets the stall timer.",
+    )
     recover.add_argument("--max-fault-resets", "--max-timer-resets", type=int, default=3)
     recover.add_argument("--fault-reset-cooldown-s", type=float, default=30.0)
     recover.add_argument("--continuous", action="store_true")

--- a/tools/battery/battery_debug.py
+++ b/tools/battery/battery_debug.py
@@ -180,8 +180,37 @@ class ChargerStatus:
         }.get(self.charging_state_code, f"unknown-{self.charging_state_code}")
 
     @property
-    def timer_fault(self) -> bool:
+    def reset_fault(self) -> bool:
         return bool(self.ctrl & (1 << 4))
+
+    @property
+    def timer_fault(self) -> bool:
+        return bool(self.ctrl & (1 << 3))
+
+    @property
+    def vindpm_active(self) -> bool:
+        return bool(self.ctrl & (1 << 2))
+
+    @property
+    def cd_stat(self) -> bool:
+        return bool(self.ctrl & (1 << 1))
+
+    @property
+    def sys_enabled(self) -> bool:
+        return bool(self.ctrl & 0x01)
+
+    @property
+    def fault_reasons(self) -> list[str]:
+        reasons = []
+        if self.timer_fault:
+            reasons.append("safety_timer")
+        if self.bat_uvlo:
+            reasons.append("BAT_UVLO")
+        if self.vindpm_active and self.charging_state_code == 3:
+            reasons.append("VINDPM")
+        if self.charging_state_code == 3 and not reasons:
+            reasons.append("unknown_status_fault")
+        return reasons
 
     @property
     def bat_uvlo(self) -> bool:
@@ -495,8 +524,14 @@ class JLinkBatteryInterface:
                 break
 
     def reset_charger(self) -> None:
+        # The BQ25120A safety-timer latch is cleared by toggling CD or power.
+        self.set_cd(1)
+        time.sleep(0.020)
+        self.set_cd(0)
+        time.sleep(0.020)
         self.bq25120a_write_u8(0x09, 0x80)
         time.sleep(0.010)
+        self.set_cd(0)
 
 
 def encode_charge_current(ma: int) -> int:
@@ -537,12 +572,18 @@ def format_status(fuel: FuelGaugeStatus, charger: ChargerStatus) -> str:
         f"voltage={fuel.voltage_mv} mV",
         f"charger={charger.charging_state}",
         f"timer_fault={charger.timer_fault}",
+        f"reset_fault={charger.reset_fault}",
         f"BAT_UVLO={charger.bat_uvlo}",
         f"charge_enabled={charger.charge_enabled}",
         f"high_z={charger.high_z}",
+        f"VINDPM={charger.vindpm_active}",
+        f"CD_stat={charger.cd_stat}",
+        f"SYS_enabled={charger.sys_enabled}",
         f"PG_present={charger.pg_present}",
         f"CD_raw={charger.cd_raw}",
     ]
+    if charger.fault_reasons:
+        fields.append(f"fault_reason={'+'.join(charger.fault_reasons)}")
     if fuel.temperature_c is not None:
         fields.append(f"temperature={fuel.temperature_c:.1f} C")
     if fuel.state_of_charge_pct is not None:
@@ -603,10 +644,18 @@ def try_reset_charger(link: JLinkBatteryInterface) -> None:
         link.reset_charger()
     except BatteryDebugError as exc:
         print(
-            f"warning: charger reset write failed; continuing with configuration: {exc}",
+            f"warning: charger reset sequence failed; continuing with configuration: {exc}",
             file=sys.stderr,
         )
         link.recover_target_state()
+
+
+def charger_recovery_reason(charger: ChargerStatus, reset_on_fault: bool) -> str | None:
+    if charger.timer_fault:
+        return "safety timer fault"
+    if reset_on_fault and charger.charging_state_code == 3 and not charger.bat_uvlo:
+        return "charger status fault"
+    return None
 
 
 def cmd_voltage(args: argparse.Namespace) -> int:
@@ -642,10 +691,15 @@ def cmd_recover(args: argparse.Namespace) -> int:
             return 2
 
         needs_recovery = fuel.voltage_mv < args.start_below_mv or args.force
-        fault_needs_reset = charger.charging_state_code == 3 and not charger.bat_uvlo
-        needs_fault_reset = args.reset_on_fault and fault_needs_reset
-        if needs_recovery or needs_fault_reset or charger.timer_fault:
-            print("resetting/configuring charger")
+        reset_reason = charger_recovery_reason(charger, args.reset_on_fault)
+        if needs_recovery or reset_reason:
+            if args.force:
+                reason = "forced"
+            elif fuel.voltage_mv < args.start_below_mv:
+                reason = f"voltage below {args.start_below_mv} mV"
+            else:
+                reason = reset_reason
+            print(f"resetting/configuring charger ({reason})")
             try_reset_charger(link)
             link.configure_charger(
                 charge_current_ma=args.charge_current_ma,
@@ -665,6 +719,7 @@ def cmd_recover(args: argparse.Namespace) -> int:
         started = time.monotonic()
         reset_count = 0
         last_reset = 0.0
+        reset_limit_warned = False
         while True:
             fuel = link.read_fuel_gauge()
             charger = link.read_charger()
@@ -678,23 +733,34 @@ def cmd_recover(args: argparse.Namespace) -> int:
                 print("Timed out before reaching target voltage.", file=sys.stderr)
                 return 1
 
-            fault_now = charger.timer_fault or (
-                args.reset_on_fault and charger.charging_state_code == 3 and not charger.bat_uvlo
-            )
+            reset_reason = charger_recovery_reason(charger, args.reset_on_fault)
             cooldown_ok = (time.monotonic() - last_reset) >= args.fault_reset_cooldown_s
-            if fault_now and cooldown_ok and reset_count < args.max_fault_resets:
-                reset_count += 1
-                last_reset = time.monotonic()
-                print(f"fault/reset condition seen; reset {reset_count}/{args.max_fault_resets}")
-                try_reset_charger(link)
-                link.configure_charger(
-                    charge_current_ma=args.charge_current_ma,
-                    termination_current_ma=args.termination_current_ma,
-                    target_voltage_mv=args.target_voltage_mv,
-                    input_limit_ma=args.input_limit_ma,
-                    uvlo_mv=args.uvlo_mv,
-                    full_config=args.full_charger_config,
-                )
+            if reset_reason and cooldown_ok:
+                if reset_count < args.max_fault_resets:
+                    reset_count += 1
+                    last_reset = time.monotonic()
+                    reset_limit_warned = False
+                    print(
+                        f"{reset_reason} seen; reset {reset_count}/{args.max_fault_resets}"
+                    )
+                    try_reset_charger(link)
+                    link.configure_charger(
+                        charge_current_ma=args.charge_current_ma,
+                        termination_current_ma=args.termination_current_ma,
+                        target_voltage_mv=args.target_voltage_mv,
+                        input_limit_ma=args.input_limit_ma,
+                        uvlo_mv=args.uvlo_mv,
+                        full_config=args.full_charger_config,
+                    )
+                elif not reset_limit_warned:
+                    print(
+                        f"warning: {reset_reason} still present but reset limit "
+                        f"({args.max_fault_resets}) has been reached. Check the "
+                        "device temperature, then rerun recovery or increase "
+                        "--max-fault-resets if continued supervised recovery is needed.",
+                        file=sys.stderr,
+                    )
+                    reset_limit_warned = True
 
             time.sleep(args.interval_s)
 

--- a/tools/battery/test_battery_debug.py
+++ b/tools/battery/test_battery_debug.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+
+import io
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+try:
+    import pylink  # noqa: F401
+except ImportError:
+    pylink = types.ModuleType("pylink")
+    pylink.JLink = object
+    pylink.errors = types.SimpleNamespace(JLinkException=Exception)
+    pylink.enums = types.ModuleType("pylink.enums")
+    pylink.enums.JLinkInterfaces = types.SimpleNamespace(SWD=1)
+    sys.modules["pylink"] = pylink
+    sys.modules["pylink.enums"] = pylink.enums
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import battery_debug as battery
+
+
+def charger_status(
+    *,
+    ctrl: int = 0x41,
+    fault: int = 0x00,
+    ts_fault: int = 0x88,
+    charge_ctrl: int = 0x9C,
+    pg_present: bool = True,
+    cd_raw: int = 0,
+) -> battery.ChargerStatus:
+    return battery.ChargerStatus(
+        ctrl=ctrl,
+        fault=fault,
+        ts_fault=ts_fault,
+        charge_ctrl=charge_ctrl,
+        ilim_uvlo=0x0A,
+        pg_present=pg_present,
+        cd_raw=cd_raw,
+    )
+
+
+def recovery_args() -> types.SimpleNamespace:
+    return types.SimpleNamespace(
+        charge_current_ma=110,
+        termination_current_ma=10.0,
+        target_voltage_mv=4300,
+        input_limit_ma=200,
+        uvlo_mv=2500,
+        full_charger_config=False,
+    )
+
+
+def fuel_status(voltage_mv: int) -> battery.FuelGaugeStatus:
+    return battery.FuelGaugeStatus(
+        voltage_mv=voltage_mv,
+        temperature_c=25.0,
+        state_of_charge_pct=5,
+        average_current_ma=10,
+        flags=0,
+        gauging_status=None,
+    )
+
+
+class ChargerStatusTests(unittest.TestCase):
+    def test_reset_and_timer_bits_are_distinct(self) -> None:
+        charging = charger_status(ctrl=0x51)
+        timer_fault = charger_status(ctrl=0xD9)
+
+        self.assertTrue(charging.reset_fault)
+        self.assertFalse(charging.timer_fault)
+        self.assertEqual(charging.fault_reasons, [])
+        self.assertTrue(timer_fault.reset_fault)
+        self.assertTrue(timer_fault.timer_fault)
+        self.assertEqual(timer_fault.fault_reasons, ["safety_timer"])
+
+    def test_all_fault_register_bits_are_named(self) -> None:
+        status = charger_status(ctrl=0xC1, fault=0xF0)
+
+        self.assertEqual(
+            status.fault_reasons,
+            ["VIN_OV", "VIN_UV", "BAT_UVLO", "BAT_OCP"],
+        )
+        self.assertEqual(status.blocking_fault_reasons, ["VIN_OV", "BAT_OCP"])
+
+    def test_temperature_states_are_named_and_classified(self) -> None:
+        suspended = charger_status(ctrl=0xC1, ts_fault=0xA8)
+        cool = charger_status(ctrl=0xC1, ts_fault=0xC8)
+        warm = charger_status(ctrl=0xC1, ts_fault=0xE8)
+
+        self.assertEqual(suspended.ts_state, "TS_hot_or_cold")
+        self.assertEqual(suspended.blocking_fault_reasons, ["TS_hot_or_cold"])
+        self.assertEqual(cool.ts_state, "TS_cool_current_reduced")
+        self.assertEqual(cool.blocking_fault_reasons, [])
+        self.assertEqual(warm.ts_state, "TS_warm_voltage_reduced")
+        self.assertEqual(warm.blocking_fault_reasons, [])
+
+    def test_only_resettable_conditions_request_a_reset(self) -> None:
+        timer = charger_status(ctrl=0xC9)
+        unknown = charger_status(ctrl=0xC1)
+        vin_undervoltage = charger_status(ctrl=0xC1, fault=0x40)
+        bat_uvlo = charger_status(ctrl=0xC1, fault=0x20)
+        vindpm = charger_status(ctrl=0xC5)
+
+        self.assertEqual(
+            battery.charger_recovery_reason(timer, False), "safety timer fault"
+        )
+        self.assertIsNone(battery.charger_recovery_reason(unknown, False))
+        self.assertEqual(
+            battery.charger_recovery_reason(unknown, True),
+            "unclassified charger status fault",
+        )
+        self.assertIsNone(battery.charger_recovery_reason(vin_undervoltage, True))
+        self.assertIsNone(battery.charger_recovery_reason(bat_uvlo, True))
+        self.assertIsNone(battery.charger_recovery_reason(vindpm, True))
+
+    def test_missing_input_power_is_blocking(self) -> None:
+        status = charger_status(pg_present=False)
+
+        self.assertEqual(
+            battery.charger_blocking_reasons(status), ["input_power_missing"]
+        )
+
+
+class ChargerControlTests(unittest.TestCase):
+    def test_cd_gpio_enables_input_for_level_verification(self) -> None:
+        interface = object.__new__(battery.JLinkBatteryInterface)
+        interface.w32 = mock.Mock()
+
+        interface.setup_gpio()
+
+        self.assertIn(
+            mock.call(
+                battery.pin_cnf(battery.CD_PIN),
+                battery.GPIO_PIN_CNF_OUTPUT_WITH_INPUT,
+            ),
+            interface.w32.call_args_list,
+        )
+
+    @mock.patch.object(battery.time, "sleep")
+    def test_cd_uses_gpio_port_offsets(self, _sleep: mock.Mock) -> None:
+        interface = object.__new__(battery.JLinkBatteryInterface)
+        interface.w32 = mock.Mock()
+
+        interface.set_cd(1)
+        interface.set_cd(0)
+
+        self.assertEqual(
+            interface.w32.call_args_list,
+            [
+                mock.call(battery.GPIO0 + 0x08, 1 << battery.CD_PIN),
+                mock.call(battery.GPIO0 + 0x0C, 1 << battery.CD_PIN),
+            ],
+        )
+
+    @mock.patch.object(battery.time, "sleep")
+    def test_reset_pulses_and_verifies_cd(self, _sleep: mock.Mock) -> None:
+        interface = object.__new__(battery.JLinkBatteryInterface)
+        interface.set_cd = mock.Mock()
+        interface.raw_gpio0_in = mock.Mock(side_effect=[1 << battery.CD_PIN, 0])
+        interface.bq25120a_write_u8 = mock.Mock()
+
+        interface.reset_charger()
+
+        self.assertEqual(
+            interface.set_cd.call_args_list,
+            [mock.call(1), mock.call(0), mock.call(0)],
+        )
+        interface.bq25120a_write_u8.assert_called_once_with(0x09, 0x80)
+
+    def test_minimal_configuration_preserves_temperature_monitoring(self) -> None:
+        interface = object.__new__(battery.JLinkBatteryInterface)
+        interface.set_cd = mock.Mock()
+        interface.bq25120a_write_u8 = mock.Mock()
+
+        interface.configure_charger(
+            charge_current_ma=110,
+            termination_current_ma=10.0,
+            target_voltage_mv=4300,
+            input_limit_ma=200,
+            uvlo_mv=2500,
+        )
+
+        interface.bq25120a_write_u8.assert_called_once_with(
+            0x03, battery.encode_charge_current(110)
+        )
+
+    @mock.patch.object(battery.time, "sleep")
+    def test_resume_target_is_verified(self, _sleep: mock.Mock) -> None:
+        interface = object.__new__(battery.JLinkBatteryInterface)
+        interface.jlink = mock.Mock()
+        interface.jlink.halted.return_value = False
+
+        interface.resume_target()
+
+        interface.jlink.restart.assert_called_once_with()
+        interface.jlink.halted.assert_called_once_with()
+
+    @mock.patch.object(battery.time, "sleep")
+    def test_recovery_verifies_timer_cleared(self, _sleep: mock.Mock) -> None:
+        link = mock.Mock()
+        link.read_charger.return_value = charger_status(ctrl=0xD9)
+
+        with (
+            mock.patch.object(sys, "stderr", new=io.StringIO()),
+            self.assertRaisesRegex(
+                battery.BatteryDebugError, "failed after two attempts"
+            ),
+        ):
+            battery.reset_and_configure_charger(link, recovery_args())
+
+        self.assertEqual(link.reset_charger.call_count, 2)
+        link.recover_target_state.assert_called_once_with()
+
+    @mock.patch.object(battery.time, "sleep")
+    def test_recovery_returns_verified_status(self, _sleep: mock.Mock) -> None:
+        link = mock.Mock()
+        expected = charger_status(ctrl=0x41)
+        link.read_charger.return_value = expected
+
+        actual = battery.reset_and_configure_charger(link, recovery_args())
+
+        self.assertIs(actual, expected)
+        link.reset_charger.assert_called_once_with()
+        link.configure_charger.assert_called_once_with(
+            charge_current_ma=110,
+            termination_current_ma=10.0,
+            target_voltage_mv=4300,
+            input_limit_ma=200,
+            uvlo_mv=2500,
+            full_config=False,
+        )
+
+    @mock.patch.object(battery.time, "sleep")
+    def test_blocking_fault_takes_priority_over_retry(self, _sleep: mock.Mock) -> None:
+        link = mock.Mock()
+        expected = charger_status(ctrl=0xD9, fault=0x10)
+        link.read_charger.return_value = expected
+
+        actual = battery.reset_and_configure_charger(link, recovery_args())
+
+        self.assertIs(actual, expected)
+        link.reset_charger.assert_called_once_with()
+        link.recover_target_state.assert_not_called()
+
+
+class RecoveryCommandTests(unittest.TestCase):
+    def recover_args(self) -> object:
+        return battery.build_parser().parse_args(
+            ["recover", "--snr", "1", "--reset-on-fault", "--interval-s", "0"]
+        )
+
+    @mock.patch.object(battery, "reset_and_configure_charger")
+    @mock.patch.object(battery, "open_link")
+    def test_timer_is_cleared_before_target_success(
+        self, open_link: mock.Mock, reset_charger: mock.Mock
+    ) -> None:
+        link = mock.MagicMock()
+        open_link.return_value = link
+        link.__enter__.return_value = link
+        link.read_fuel_gauge.side_effect = [fuel_status(3400), fuel_status(3400)]
+        link.read_charger.side_effect = [
+            charger_status(ctrl=0xD9),
+            charger_status(ctrl=0x41),
+        ]
+        reset_charger.return_value = charger_status(ctrl=0x41)
+
+        with mock.patch.object(sys, "stdout", new=io.StringIO()):
+            result = battery.cmd_recover(self.recover_args())
+
+        self.assertEqual(result, 0)
+        reset_charger.assert_called_once_with(link, mock.ANY)
+
+    @mock.patch.object(battery, "reset_and_configure_charger")
+    @mock.patch.object(battery, "open_link")
+    def test_physical_fault_stops_without_reset(
+        self, open_link: mock.Mock, reset_charger: mock.Mock
+    ) -> None:
+        link = mock.MagicMock()
+        open_link.return_value = link
+        link.__enter__.return_value = link
+        link.read_fuel_gauge.return_value = fuel_status(3400)
+        link.read_charger.return_value = charger_status(ctrl=0xC1, fault=0x80)
+
+        with (
+            mock.patch.object(sys, "stdout", new=io.StringIO()),
+            mock.patch.object(sys, "stderr", new=io.StringIO()),
+        ):
+            result = battery.cmd_recover(self.recover_args())
+
+        self.assertEqual(result, 1)
+        reset_charger.assert_not_called()
+
+    @mock.patch.object(battery, "reset_and_configure_charger")
+    @mock.patch.object(battery, "open_link")
+    def test_physical_fault_seen_during_reset_is_not_lost(
+        self, open_link: mock.Mock, reset_charger: mock.Mock
+    ) -> None:
+        link = mock.MagicMock()
+        open_link.return_value = link
+        link.__enter__.return_value = link
+        link.read_fuel_gauge.return_value = fuel_status(3400)
+        link.read_charger.return_value = charger_status(ctrl=0xD9)
+        reset_charger.return_value = charger_status(ctrl=0xC1, fault=0x10)
+
+        with (
+            mock.patch.object(sys, "stdout", new=io.StringIO()),
+            mock.patch.object(sys, "stderr", new=io.StringIO()),
+        ):
+            result = battery.cmd_recover(self.recover_args())
+
+        self.assertEqual(result, 1)
+        reset_charger.assert_called_once_with(link, mock.ANY)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/battery/test_battery_debug.py
+++ b/tools/battery/test_battery_debug.py
@@ -171,6 +171,20 @@ class ChargerControlTests(unittest.TestCase):
         )
         interface.bq25120a_write_u8.assert_called_once_with(0x09, 0x80)
 
+    @mock.patch.object(battery.time, "sleep")
+    def test_reset_restores_cd_low_when_high_write_fails(
+        self, _sleep: mock.Mock
+    ) -> None:
+        interface = object.__new__(battery.JLinkBatteryInterface)
+        interface.set_cd = mock.Mock(
+            side_effect=[battery.BatteryDebugError("write failed"), None]
+        )
+
+        with self.assertRaisesRegex(battery.BatteryDebugError, "write failed"):
+            interface.reset_charger()
+
+        self.assertEqual(interface.set_cd.call_args_list, [mock.call(1), mock.call(0)])
+
     def test_minimal_configuration_preserves_temperature_monitoring(self) -> None:
         interface = object.__new__(battery.JLinkBatteryInterface)
         interface.set_cd = mock.Mock()
@@ -235,6 +249,24 @@ class ChargerControlTests(unittest.TestCase):
         )
 
     @mock.patch.object(battery.time, "sleep")
+    def test_recovery_retries_when_current_configuration_does_not_stick(
+        self, _sleep: mock.Mock
+    ) -> None:
+        link = mock.Mock()
+        link.read_charger.return_value = charger_status(charge_ctrl=0x14)
+
+        with (
+            mock.patch.object(sys, "stderr", new=io.StringIO()),
+            self.assertRaisesRegex(
+                battery.BatteryDebugError, "current configuration did not stick"
+            ),
+        ):
+            battery.reset_and_configure_charger(link, recovery_args())
+
+        self.assertEqual(link.reset_charger.call_count, 2)
+        link.recover_target_state.assert_called_once_with()
+
+    @mock.patch.object(battery.time, "sleep")
     def test_blocking_fault_takes_priority_over_retry(self, _sleep: mock.Mock) -> None:
         link = mock.Mock()
         expected = charger_status(ctrl=0xD9, fault=0x10)
@@ -247,10 +279,133 @@ class ChargerControlTests(unittest.TestCase):
         link.recover_target_state.assert_not_called()
 
 
+class JLinkLifecycleTests(unittest.TestCase):
+    def interface(self) -> battery.JLinkBatteryInterface:
+        interface = object.__new__(battery.JLinkBatteryInterface)
+        interface.snr = 1
+        interface.speed_khz = 1000
+        interface.resume = True
+        interface.reset_target = False
+        interface.jlink = mock.Mock()
+        interface.was_halted = False
+        interface.probe_open = False
+        interface.target_connected = False
+        interface.resume_on_exit = False
+        interface.setup_gpio = mock.Mock()
+        interface.setup_twim = mock.Mock()
+        return interface
+
+    @mock.patch.object(battery.time, "sleep")
+    def test_enter_failure_resumes_running_target_and_closes_probe(
+        self, _sleep: mock.Mock
+    ) -> None:
+        interface = self.interface()
+        interface.jlink.halted.side_effect = [False, False]
+        interface.setup_gpio.side_effect = battery.BatteryDebugError("setup failed")
+
+        with self.assertRaisesRegex(battery.BatteryDebugError, "setup failed"):
+            interface.__enter__()
+
+        interface.jlink.halt.assert_called_once_with()
+        interface.jlink.restart.assert_called_once_with()
+        interface.jlink.close.assert_called_once_with()
+        self.assertFalse(interface.probe_open)
+
+    def test_enter_failure_preserves_target_that_was_already_halted(self) -> None:
+        interface = self.interface()
+        interface.jlink.halted.return_value = True
+        interface.setup_gpio.side_effect = battery.BatteryDebugError("setup failed")
+
+        with self.assertRaisesRegex(battery.BatteryDebugError, "setup failed"):
+            interface.__enter__()
+
+        interface.jlink.halt.assert_not_called()
+        interface.jlink.restart.assert_not_called()
+        interface.jlink.close.assert_called_once_with()
+
+    def test_open_failure_still_closes_probe_handle(self) -> None:
+        interface = self.interface()
+        interface.jlink.open.side_effect = battery.BatteryDebugError("open failed")
+
+        with self.assertRaisesRegex(battery.BatteryDebugError, "open failed"):
+            interface.__enter__()
+
+        interface.jlink.close.assert_called_once_with()
+
+
+class TwimTests(unittest.TestCase):
+    def interface(self) -> battery.JLinkBatteryInterface:
+        interface = object.__new__(battery.JLinkBatteryInterface)
+        interface.setup_twim = mock.Mock()
+        interface.clear_twim_events = mock.Mock()
+        interface.wait_twim = mock.Mock()
+        interface.w8 = mock.Mock()
+        interface.w32 = mock.Mock()
+        interface.r8 = mock.Mock()
+        interface.r32 = mock.Mock()
+        return interface
+
+    def test_twim_error_is_checked_before_stopped_and_sends_stop(self) -> None:
+        interface = self.interface()
+        interface.r32.side_effect = [1, battery.TWIM_ERROR_ANACK, 1, 0]
+        interface.stop_twim = mock.Mock(return_value=True)
+
+        with self.assertRaisesRegex(battery.BatteryDebugError, "address NACK"):
+            interface.wait_twim = battery.JLinkBatteryInterface.wait_twim.__get__(
+                interface
+            )
+            interface.wait_twim()
+
+        self.assertEqual(
+            interface.r32.call_args_list[0],
+            mock.call(battery.TWIM1 + battery.EVENTS_ERROR),
+        )
+        interface.stop_twim.assert_called_once_with()
+
+    def test_timeout_reports_bus_line_levels(self) -> None:
+        interface = self.interface()
+        interface.r32.side_effect = [0, 1, 0]
+        interface.raw_gpio0_in = mock.Mock(return_value=1 << battery.SCL_PIN)
+        interface.stop_twim = mock.Mock(return_value=True)
+
+        with self.assertRaisesRegex(
+            battery.BatteryDebugError, "SCL=high, SDA=low"
+        ):
+            battery.JLinkBatteryInterface.wait_twim(interface, timeout_s=0)
+
+    def test_register_read_accepts_value_equal_to_old_sentinel(self) -> None:
+        interface = self.interface()
+        interface.r32.side_effect = [1, 1]
+        interface.r8.return_value = [0xCF]
+
+        actual = interface.i2c_read_reg(battery.BQ25120A_ADDR, 0x00, 1)
+
+        self.assertEqual(actual, [0xCF])
+
+    def test_register_read_clears_shorts_after_transaction_error(self) -> None:
+        interface = self.interface()
+        interface.wait_twim.side_effect = battery.BatteryDebugError("transaction failed")
+
+        with self.assertRaisesRegex(battery.BatteryDebugError, "transaction failed"):
+            interface.i2c_read_reg(battery.BQ25120A_ADDR, 0x00, 1)
+
+        self.assertEqual(
+            interface.w32.call_args_list[-1],
+            mock.call(battery.TWIM1 + battery.TWIM_SHORTS, 0),
+        )
+
+
 class RecoveryCommandTests(unittest.TestCase):
     def recover_args(self) -> object:
         return battery.build_parser().parse_args(
-            ["recover", "--snr", "1", "--reset-on-fault", "--interval-s", "0"]
+            [
+                "recover",
+                "--snr",
+                "1",
+                "--reset-on-fault",
+                "--interval-s",
+                "0.001",
+            ]
         )
 
     @mock.patch.object(battery, "reset_and_configure_charger")
@@ -314,6 +469,72 @@ class RecoveryCommandTests(unittest.TestCase):
 
         self.assertEqual(result, 1)
         reset_charger.assert_called_once_with(link, mock.ANY)
+
+    @mock.patch.object(battery, "reset_and_configure_charger")
+    @mock.patch.object(battery, "open_link")
+    def test_max_timeout_applies_while_fault_reset_is_in_cooldown(
+        self, open_link: mock.Mock, reset_charger: mock.Mock
+    ) -> None:
+        link = mock.MagicMock()
+        open_link.return_value = link
+        link.__enter__.return_value = link
+        link.read_fuel_gauge.side_effect = [fuel_status(2900), fuel_status(2900)]
+        link.read_charger.side_effect = [
+            charger_status(ctrl=0x41),
+            charger_status(ctrl=0xD9),
+        ]
+        reset_charger.return_value = charger_status(ctrl=0x41)
+        args = self.recover_args()
+        args.max_minutes = 1e-12
+
+        with (
+            mock.patch.object(sys, "stdout", new=io.StringIO()),
+            mock.patch.object(sys, "stderr", new=io.StringIO()),
+        ):
+            result = battery.cmd_recover(args)
+
+        self.assertEqual(result, 1)
+        reset_charger.assert_called_once_with(link, args)
+
+
+class ArgumentTests(unittest.TestCase):
+    def test_invalid_values_are_rejected_without_tracebacks(self) -> None:
+        invalid_cases = [
+            (["status", "--snr", "not-a-number"], "must be an integer"),
+            (["status", "--snr", "-1"], "must be greater than zero"),
+            (["status", "--speed-khz", "0"], "must be greater than zero"),
+            (["recover", "--interval-s", "0"], "greater than zero"),
+            (["recover", "--interval-s", "31"], "watchdog"),
+            (["recover", "--max-minutes", "-1"], "zero or greater"),
+            (["recover", "--stall-minutes", "nan"], "finite number"),
+            (["recover", "--max-fault-resets", "-1"], "zero or greater"),
+        ]
+
+        for argv, expected in invalid_cases:
+            with self.subTest(argv=argv):
+                stderr = io.StringIO()
+                with (
+                    mock.patch.object(sys, "stderr", new=stderr),
+                    self.assertRaises(SystemExit) as raised,
+                ):
+                    battery.build_parser().parse_args(argv)
+                self.assertEqual(raised.exception.code, 2)
+                self.assertIn(expected, stderr.getvalue())
+                self.assertNotIn("Traceback", stderr.getvalue())
+
+    def test_keyboard_interrupt_is_reported_cleanly(self) -> None:
+        stderr = io.StringIO()
+        with (
+            mock.patch.object(
+                battery, "cmd_voltage", side_effect=KeyboardInterrupt
+            ),
+            mock.patch.object(sys, "stderr", new=stderr),
+        ):
+            result = battery.main(["voltage"])
+
+        self.assertEqual(result, 130)
+        self.assertIn("battery_debug: interrupted.", stderr.getvalue())
+        self.assertNotIn("Traceback", stderr.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
- Correct the nRF5340 GPIO offsets so the charger CD pin is actually pulsed
- Verify CD high/low levels, charger-current configuration, and safety-timer clearing
- Decode VIN, battery overcurrent, temperature, VINDPM, reset, and timer states
- Separate resettable conditions from electrical faults that require a safe stop
- Make TWIM failures identify NACKs and stuck bus lines, and always issue STOP on errors
- Clean up and resume the target after setup failures or Ctrl-C
- Detect stalled recovery, enforce timeout/reset limits, and reject unsafe polling values
- Preserve charger temperature monitoring and document recovery behavior

Testing:
- 28 unit tests: python3 -m unittest discover -s tools/battery -p "test_*.py" -v
- python3 -m py_compile tools/battery/battery_debug.py tools/battery/test_battery_debug.py
- python3 tools/battery/battery_debug.py recover --help
- Missing-probe CLI failure path
- git diff --check

Hardware validation:
- Not run in this pass because no J-Link probe is connected.
