### PR TITLE
Fix battery recovery charger writes

### DIFF
--- a/tools/battery/README.md
+++ b/tools/battery/README.md
@@ -112,10 +112,17 @@ python3 tools/battery/battery_debug.py recover --snr [YOUR_JLINK_SERIAL_NUMBER] 
 
 During recovery, safety-timer faults are reset even without `--reset-on-fault`.
 The reset sequence pulses the charger `CD` pin, verifies that it moved high and
-back low, resets the charger registers, restores the charger configuration, and
-checks that the timer fault cleared. A failed sequence is retried once. If a
-fault returns until `--max-fault-resets` is reached, recovery stops with an
-error instead of silently continuing with charging stopped.
+back low, resets the charger registers, restores fast-charge current,
+precharge/termination current, input current limit, and battery UVLO, and checks
+that those settings and the cleared timer fault read back correctly. A failed
+sequence is retried once. If a fault returns until `--max-fault-resets` is
+reached, recovery stops with an error instead of silently continuing with
+charging stopped.
+
+Restoring precharge and battery UVLO is important for deeply discharged cells.
+The BQ25120A reset defaults use 2 mA precharge and a 3.0 V battery UVLO threshold
+with hysteresis. Recovery instead applies the verified OpenEarable settings of
+10 mA precharge and 2.6 V UVLO, avoiding a prolonged low-current plateau.
 
 `BAT_UVLO`, VINDPM, and the cool/warm temperature derating states do not trigger
 repeated resets; recovery monitors them while voltage progresses. Missing input

--- a/tools/battery/battery_debug.py
+++ b/tools/battery/battery_debug.py
@@ -28,6 +28,10 @@ except ImportError as exc:  # pragma: no cover - depends on local workstation
 
 APP_CORE_DEVICE = "NRF5340_XXAA_APP"
 DEFAULT_SPEED_KHZ = 1000
+RECOVERY_CHARGE_CURRENT_MA = 110
+RECOVERY_PRETERM_CURRENT_MA = 10.0
+RECOVERY_INPUT_LIMIT_MA = 200
+RECOVERY_UVLO_MV = 2500
 
 TWIM1 = 0x50009000
 GPIO0 = 0x50842500
@@ -78,7 +82,8 @@ EVENTS_LASTRX = 0x15C
 EVENTS_LASTTX = 0x160
 
 SHORT_LASTTX_STARTRX = 1 << 7
-SHORT_LASTTX_STOP = 1 << 8
+# Bit 8 is LASTTX_SUSPEND on nRF5340; a completed write needs LASTTX_STOP.
+SHORT_LASTTX_STOP = 1 << 9
 SHORT_LASTRX_STOP = 1 << 12
 
 TWIM_ERROR_OVERRUN = 1 << 0
@@ -188,6 +193,7 @@ class ChargerStatus:
     fault: int
     ts_fault: int
     charge_ctrl: int
+    preterm_ctrl: int
     ilim_uvlo: int
     pg_present: bool
     cd_raw: int
@@ -640,40 +646,31 @@ class JLinkBatteryInterface:
             fault=self.bq25120a_u8(0x01),
             ts_fault=self.bq25120a_u8(0x02),
             charge_ctrl=self.bq25120a_u8(0x03),
+            preterm_ctrl=self.bq25120a_u8(0x04),
             ilim_uvlo=self.bq25120a_u8(0x09),
             pg_present=not bool(raw_in & (1 << PG_PIN)),
             cd_raw=1 if raw_in & (1 << CD_PIN) else 0,
         )
 
-    def configure_charger(
-        self,
-        charge_current_ma: int,
-        termination_current_ma: float,
-        target_voltage_mv: int,
-        input_limit_ma: int,
-        uvlo_mv: int,
-        full_config: bool = False,
-    ) -> None:
+    def configure_charger(self) -> None:
         self.set_cd(0)
         writes = [
-            (0x03, encode_charge_current(charge_current_ma), "set charge current"),
+            (
+                0x03,
+                encode_charge_current(RECOVERY_CHARGE_CURRENT_MA),
+                "set charge current",
+            ),
+            (
+                0x04,
+                encode_termination_current(RECOVERY_PRETERM_CURRENT_MA),
+                "set precharge/termination current",
+            ),
+            (
+                0x09,
+                encode_ilim_uvlo(RECOVERY_INPUT_LIMIT_MA, RECOVERY_UVLO_MV),
+                "set input limit/UVLO",
+            ),
         ]
-        if full_config:
-            writes[0:0] = [(0x05, encode_target_voltage(target_voltage_mv), "set target voltage")]
-            writes.extend(
-                [
-                    (
-                        0x04,
-                        encode_termination_current(termination_current_ma),
-                        "set termination current",
-                    ),
-                    (
-                        0x09,
-                        encode_ilim_uvlo(input_limit_ma, uvlo_mv),
-                        "set input limit/UVLO",
-                    ),
-                ]
-            )
         for reg, value, description in writes:
             try:
                 self.bq25120a_write_u8(reg, value)
@@ -717,11 +714,6 @@ def encode_termination_current(ma: float) -> int:
     return value | 0x02
 
 
-def encode_target_voltage(mv: int) -> int:
-    volts = max(3.6, min(4.65, mv / 1000.0))
-    return (int(round((volts - 3.6) * 100)) & 0x7F) << 1
-
-
 def encode_ilim_uvlo(input_limit_ma: int, uvlo_mv: int) -> int:
     ilim = max(50, min(400, int(input_limit_ma)))
     uvlo = max(2200, min(3000, int(uvlo_mv))) / 1000.0
@@ -763,6 +755,7 @@ def format_status(fuel: FuelGaugeStatus, charger: ChargerStatus) -> str:
             f"charger_fault=0x{charger.fault:02x}",
             f"ts_fault=0x{charger.ts_fault:02x}",
             f"charge_ctrl=0x{charger.charge_ctrl:02x}",
+            f"preterm_ctrl=0x{charger.preterm_ctrl:02x}",
             f"ilim_uvlo=0x{charger.ilim_uvlo:02x}",
         ]
     )
@@ -893,21 +886,12 @@ def charger_recovery_reason(charger: ChargerStatus, reset_on_fault: bool) -> str
     return None
 
 
-def reset_and_configure_charger(
-    link: JLinkBatteryInterface, args: argparse.Namespace
-) -> ChargerStatus:
+def reset_and_configure_charger(link: JLinkBatteryInterface) -> ChargerStatus:
     last_error = None
     for attempt in range(2):
         try:
             link.reset_charger()
-            link.configure_charger(
-                charge_current_ma=args.charge_current_ma,
-                termination_current_ma=args.termination_current_ma,
-                target_voltage_mv=args.target_voltage_mv,
-                input_limit_ma=args.input_limit_ma,
-                uvlo_mv=args.uvlo_mv,
-                full_config=args.full_charger_config,
-            )
+            link.configure_charger()
             time.sleep(0.050)
             charger = link.read_charger()
             if charger_blocking_reasons(charger):
@@ -928,12 +912,30 @@ def reset_and_configure_charger(
                 raise BatteryDebugError(
                     "charger system output remained disabled after reset"
                 )
-            expected_charge_ctrl = encode_charge_current(args.charge_current_ma)
+            expected_charge_ctrl = encode_charge_current(RECOVERY_CHARGE_CURRENT_MA)
             if charger.charge_ctrl != expected_charge_ctrl:
                 raise BatteryDebugError(
                     "charger current configuration did not stick: "
                     f"read 0x{charger.charge_ctrl:02x}, expected "
                     f"0x{expected_charge_ctrl:02x}"
+                )
+            expected_preterm_ctrl = encode_termination_current(
+                RECOVERY_PRETERM_CURRENT_MA
+            )
+            if charger.preterm_ctrl != expected_preterm_ctrl:
+                raise BatteryDebugError(
+                    "charger precharge/termination configuration did not stick: "
+                    f"read 0x{charger.preterm_ctrl:02x}, expected "
+                    f"0x{expected_preterm_ctrl:02x}"
+                )
+            expected_ilim_uvlo = encode_ilim_uvlo(
+                RECOVERY_INPUT_LIMIT_MA, RECOVERY_UVLO_MV
+            )
+            if charger.ilim_uvlo != expected_ilim_uvlo:
+                raise BatteryDebugError(
+                    "charger input-limit/UVLO configuration did not stick: "
+                    f"read 0x{charger.ilim_uvlo:02x}, expected "
+                    f"0x{expected_ilim_uvlo:02x}"
                 )
             return charger
         except BatteryDebugError as exc:
@@ -999,7 +1001,7 @@ def cmd_recover(args: argparse.Namespace) -> int:
             else:
                 reason = reset_reason
             print(f"resetting/configuring charger ({reason})")
-            charger = reset_and_configure_charger(link, args)
+            charger = reset_and_configure_charger(link)
             print("after reset:", format_status(fuel, charger))
             blockers = charger_blocking_reasons(charger)
             if blockers:
@@ -1084,7 +1086,7 @@ def cmd_recover(args: argparse.Namespace) -> int:
                         f"{reset_reason} seen; reset "
                         f"{reset_count}/{args.max_fault_resets}"
                     )
-                    charger = reset_and_configure_charger(link, args)
+                    charger = reset_and_configure_charger(link)
                     print("after reset:", format_status(fuel, charger))
                     blockers = charger_blocking_reasons(charger)
                     if blockers:
@@ -1149,13 +1151,6 @@ def build_parser() -> argparse.ArgumentParser:
     recover.add_argument("--start-below-mv", type=positive_int_arg, default=3000)
     recover.add_argument("--target-mv", type=positive_int_arg, default=3300)
     recover.add_argument("--min-safe-mv", type=positive_int_arg, default=2500)
-    recover.add_argument("--charge-current-ma", type=positive_int_arg, default=110)
-    recover.add_argument(
-        "--termination-current-ma", type=positive_float_arg, default=10.0
-    )
-    recover.add_argument("--target-voltage-mv", type=positive_int_arg, default=4300)
-    recover.add_argument("--input-limit-ma", type=positive_int_arg, default=200)
-    recover.add_argument("--uvlo-mv", type=positive_int_arg, default=2500)
     recover.add_argument("--interval-s", type=monitoring_interval_arg, default=10.0)
     recover.add_argument("--max-minutes", type=nonnegative_float_arg, default=0.0)
     recover.add_argument(
@@ -1183,14 +1178,6 @@ def build_parser() -> argparse.ArgumentParser:
     recover.add_argument("--reset-on-fault", action="store_true")
     recover.add_argument("--force", action="store_true")
     recover.add_argument("--allow-deep-discharge", action="store_true")
-    recover.add_argument(
-        "--full-charger-config",
-        action="store_true",
-        help=(
-            "Also write target-voltage, termination, and input-limit registers. "
-            "By default recovery only writes the stable minimal charger sequence."
-        ),
-    )
     recover.set_defaults(func=cmd_recover, reset_target=True)
 
     return parser

--- a/tools/battery/test_battery_debug.py
+++ b/tools/battery/test_battery_debug.py
@@ -29,6 +29,8 @@ def charger_status(
     fault: int = 0x00,
     ts_fault: int = 0x88,
     charge_ctrl: int = 0x9C,
+    preterm_ctrl: int = 0x92,
+    ilim_uvlo: int = 0x1C,
     pg_present: bool = True,
     cd_raw: int = 0,
 ) -> battery.ChargerStatus:
@@ -37,20 +39,10 @@ def charger_status(
         fault=fault,
         ts_fault=ts_fault,
         charge_ctrl=charge_ctrl,
-        ilim_uvlo=0x0A,
+        preterm_ctrl=preterm_ctrl,
+        ilim_uvlo=ilim_uvlo,
         pg_present=pg_present,
         cd_raw=cd_raw,
-    )
-
-
-def recovery_args() -> types.SimpleNamespace:
-    return types.SimpleNamespace(
-        charge_current_ma=110,
-        termination_current_ma=10.0,
-        target_voltage_mv=4300,
-        input_limit_ma=200,
-        uvlo_mv=2500,
-        full_charger_config=False,
     )
 
 
@@ -185,21 +177,36 @@ class ChargerControlTests(unittest.TestCase):
 
         self.assertEqual(interface.set_cd.call_args_list, [mock.call(1), mock.call(0)])
 
-    def test_minimal_configuration_preserves_temperature_monitoring(self) -> None:
+    def test_recovery_configuration_sets_current_precharge_and_uvlo(self) -> None:
         interface = object.__new__(battery.JLinkBatteryInterface)
         interface.set_cd = mock.Mock()
         interface.bq25120a_write_u8 = mock.Mock()
 
-        interface.configure_charger(
-            charge_current_ma=110,
-            termination_current_ma=10.0,
-            target_voltage_mv=4300,
-            input_limit_ma=200,
-            uvlo_mv=2500,
-        )
+        interface.configure_charger()
 
-        interface.bq25120a_write_u8.assert_called_once_with(
-            0x03, battery.encode_charge_current(110)
+        self.assertEqual(
+            interface.bq25120a_write_u8.call_args_list,
+            [
+                mock.call(
+                    0x03,
+                    battery.encode_charge_current(
+                        battery.RECOVERY_CHARGE_CURRENT_MA
+                    ),
+                ),
+                mock.call(
+                    0x04,
+                    battery.encode_termination_current(
+                        battery.RECOVERY_PRETERM_CURRENT_MA
+                    ),
+                ),
+                mock.call(
+                    0x09,
+                    battery.encode_ilim_uvlo(
+                        battery.RECOVERY_INPUT_LIMIT_MA,
+                        battery.RECOVERY_UVLO_MV,
+                    ),
+                ),
+            ],
         )
 
     @mock.patch.object(battery.time, "sleep")
@@ -224,7 +231,7 @@ class ChargerControlTests(unittest.TestCase):
                 battery.BatteryDebugError, "failed after two attempts"
             ),
         ):
-            battery.reset_and_configure_charger(link, recovery_args())
+            battery.reset_and_configure_charger(link)
 
         self.assertEqual(link.reset_charger.call_count, 2)
         link.recover_target_state.assert_called_once_with()
@@ -235,18 +242,11 @@ class ChargerControlTests(unittest.TestCase):
         expected = charger_status(ctrl=0x41)
         link.read_charger.return_value = expected
 
-        actual = battery.reset_and_configure_charger(link, recovery_args())
+        actual = battery.reset_and_configure_charger(link)
 
         self.assertIs(actual, expected)
         link.reset_charger.assert_called_once_with()
-        link.configure_charger.assert_called_once_with(
-            charge_current_ma=110,
-            termination_current_ma=10.0,
-            target_voltage_mv=4300,
-            input_limit_ma=200,
-            uvlo_mv=2500,
-            full_config=False,
-        )
+        link.configure_charger.assert_called_once_with()
 
     @mock.patch.object(battery.time, "sleep")
     def test_recovery_retries_when_current_configuration_does_not_stick(
@@ -261,7 +261,43 @@ class ChargerControlTests(unittest.TestCase):
                 battery.BatteryDebugError, "current configuration did not stick"
             ),
         ):
-            battery.reset_and_configure_charger(link, recovery_args())
+            battery.reset_and_configure_charger(link)
+
+        self.assertEqual(link.reset_charger.call_count, 2)
+        link.recover_target_state.assert_called_once_with()
+
+    @mock.patch.object(battery.time, "sleep")
+    def test_recovery_retries_when_uvlo_configuration_does_not_stick(
+        self, _sleep: mock.Mock
+    ) -> None:
+        link = mock.Mock()
+        link.read_charger.return_value = charger_status(ilim_uvlo=0x0A)
+
+        with (
+            mock.patch.object(sys, "stderr", new=io.StringIO()),
+            self.assertRaisesRegex(
+                battery.BatteryDebugError, "input-limit/UVLO configuration"
+            ),
+        ):
+            battery.reset_and_configure_charger(link)
+
+        self.assertEqual(link.reset_charger.call_count, 2)
+        link.recover_target_state.assert_called_once_with()
+
+    @mock.patch.object(battery.time, "sleep")
+    def test_recovery_retries_when_precharge_configuration_does_not_stick(
+        self, _sleep: mock.Mock
+    ) -> None:
+        link = mock.Mock()
+        link.read_charger.return_value = charger_status(preterm_ctrl=0x00)
+
+        with (
+            mock.patch.object(sys, "stderr", new=io.StringIO()),
+            self.assertRaisesRegex(
+                battery.BatteryDebugError, "precharge/termination configuration"
+            ),
+        ):
+            battery.reset_and_configure_charger(link)
 
         self.assertEqual(link.reset_charger.call_count, 2)
         link.recover_target_state.assert_called_once_with()
@@ -272,7 +308,7 @@ class ChargerControlTests(unittest.TestCase):
         expected = charger_status(ctrl=0xD9, fault=0x10)
         link.read_charger.return_value = expected
 
-        actual = battery.reset_and_configure_charger(link, recovery_args())
+        actual = battery.reset_and_configure_charger(link)
 
         self.assertIs(actual, expected)
         link.reset_charger.assert_called_once_with()
@@ -382,6 +418,21 @@ class TwimTests(unittest.TestCase):
 
         self.assertEqual(actual, [0xCF])
 
+    def test_write_stops_after_last_transmitted_byte(self) -> None:
+        interface = self.interface()
+        interface.r32.return_value = 2
+
+        interface.i2c_write(battery.BQ25120A_ADDR, [0x03, 0x9C])
+
+        self.assertIn(
+            mock.call(battery.TWIM1 + battery.TWIM_SHORTS, 1 << 9),
+            interface.w32.call_args_list,
+        )
+        self.assertNotIn(
+            mock.call(battery.TWIM1 + battery.TWIM_SHORTS, 1 << 8),
+            interface.w32.call_args_list,
+        )
+
     def test_register_read_clears_shorts_after_transaction_error(self) -> None:
         interface = self.interface()
         interface.wait_twim.side_effect = battery.BatteryDebugError("transaction failed")
@@ -427,7 +478,7 @@ class RecoveryCommandTests(unittest.TestCase):
             result = battery.cmd_recover(self.recover_args())
 
         self.assertEqual(result, 0)
-        reset_charger.assert_called_once_with(link, mock.ANY)
+        reset_charger.assert_called_once_with(link)
 
     @mock.patch.object(battery, "reset_and_configure_charger")
     @mock.patch.object(battery, "open_link")
@@ -468,7 +519,7 @@ class RecoveryCommandTests(unittest.TestCase):
             result = battery.cmd_recover(self.recover_args())
 
         self.assertEqual(result, 1)
-        reset_charger.assert_called_once_with(link, mock.ANY)
+        reset_charger.assert_called_once_with(link)
 
     @mock.patch.object(battery, "reset_and_configure_charger")
     @mock.patch.object(battery, "open_link")
@@ -494,7 +545,7 @@ class RecoveryCommandTests(unittest.TestCase):
             result = battery.cmd_recover(args)
 
         self.assertEqual(result, 1)
-        reset_charger.assert_called_once_with(link, args)
+        reset_charger.assert_called_once_with(link)
 
 
 class ArgumentTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- fix the nRF5340 TWIM write shortcut so charger writes issue STOP instead of suspending with SCL low
- always apply and verify the tested OpenEarable charge-current, precharge, input-limit, and battery-UVLO settings after charger reset
- remove charger-tuning flags so the standard recovery command has one reliable configuration
- expose the precharge register in status output and document deep-discharge recovery behavior

## Verification
- `python3 -m unittest discover -s tools/battery -p 'test_*.py' -v` (31 tests)\n- `python3 -m py_compile tools/battery/battery_debug.py tools/battery/test_battery_debug.py`\n- hardware recovery on J-Link serial 261010806: BAT_UVLO cleared, current increased to 88-113 mA, voltage exceeded 3300 mV, fixed settings read back correctly, and the application core restarted