### PR TITLE
Add BMI160 and external BMM150 support for hardware 2.1.0

### DIFF
--- a/src/SensorManager/BMX160/DFRobot_BMX160.cpp
+++ b/src/SensorManager/BMX160/DFRobot_BMX160.cpp
@@ -44,20 +44,62 @@ const uint8_t int_mask_lookup_table[13] = {
 bool DFRobot_BMX160::begin()
 {
     _i2c->begin();
-    
-    if (scan() == true){
-        softReset();
-        writeBmxReg(BMX160_COMMAND_REG_ADDR, 0x11);
-        delay(50);
-        /* Set gyro to normal mode */
-        writeBmxReg(BMX160_COMMAND_REG_ADDR, 0x15);
-        delay(100);
-        /* Set mag to normal mode */
-        writeBmxReg(BMX160_COMMAND_REG_ADDR, 0x19);
-        delay(10);
-        setMagnConf();
+
+    if (!detect() || !softReset()) {
+        return false;
+    }
+
+    writeBmxReg(BMX160_COMMAND_REG_ADDR, 0x11);
+    delay(50);
+    /* Set gyro to normal mode */
+    writeBmxReg(BMX160_COMMAND_REG_ADDR, 0x15);
+    delay(100);
+    /* Set mag to normal mode */
+    writeBmxReg(BMX160_COMMAND_REG_ADDR, 0x19);
+    delay(10);
+
+    return setMagnConf();
+}
+
+bool DFRobot_BMX160::detect()
+{
+    _i2c->begin();
+
+    uint8_t chip_id = 0;
+
+    /* Revision 2.1 selects the alternate address by pulling BMI160 SDO high. */
+    if (probeAddress(BMI160_I2C_ADDR_SDO_HIGH, &chip_id) && chip_id == BMI160_CHIP_ID) {
+        _addr = BMI160_I2C_ADDR_SDO_HIGH;
+        _standaloneBmi160 = true;
+        LOG_INF("Standalone BMI160 detected at 0x%02x", _addr);
         return true;
-    } else return false;
+    }
+
+    if (probeAddress(BMI160_I2C_ADDR_SDO_LOW, &chip_id) &&
+        (chip_id == BMX160_CHIP_ID || chip_id == BMI160_CHIP_ID)) {
+        _addr = BMI160_I2C_ADDR_SDO_LOW;
+        _standaloneBmi160 = false;
+        LOG_INF("%s detected at 0x%02x", chip_id == BMX160_CHIP_ID ? "BMX160" : "BMI160", _addr);
+        return true;
+    }
+
+    _standaloneBmi160 = false;
+    LOG_WRN("No BMI160/BMX160 found at 0x68 or 0x69");
+    return false;
+}
+
+bool DFRobot_BMX160::isStandaloneBmi160() const
+{
+    return _standaloneBmi160;
+}
+
+bool DFRobot_BMX160::probeAddress(uint8_t addr, uint8_t *chip_id)
+{
+    _i2c->aquire();
+    const int ret = i2c_burst_read(_i2c->master, addr, BMX160_CHIP_ID_ADDR, chip_id, 1);
+    _i2c->release();
+
+    return ret == 0;
 }
 
 void DFRobot_BMX160::setLowPower(){
@@ -141,14 +183,14 @@ void DFRobot_BMX160::defaultParamSettg(sBmx160Dev_t *dev)
 
 bool DFRobot_BMX160::setMagnConf()
 {
+    _bmm150Ready = false;
+
     if (setBmi160AuxMagnConf()) {
         LOG_INF("BMM150 magnetometer configured through BMI160 auxiliary interface");
         return true;
     }
 
-    LOG_WRN("BMM150 auxiliary probe failed; using BMX160 magnetometer interface fallback");
-    setBmx160MagnConf();
-
+    LOG_ERR("BMM150 auxiliary probe or configuration failed");
     return false;
 }
 
@@ -172,7 +214,7 @@ bool DFRobot_BMX160::setBmi160AuxMagnConf()
     }
     delay(BMX160_MAGN_COM_DELAY);
 
-    if (!setBmi160AuxMode(true, 0x00)) {
+    if (!setBmi160AuxMode(true, 0x03)) {
         return false;
     }
 
@@ -186,7 +228,8 @@ bool DFRobot_BMX160::setBmi160AuxMagnConf()
         return false;
     }
 
-    if (!writeBmm150Reg(BMM150_REP_XY_ADDR, BMM150_REP_XY_REGULAR) ||
+    if (!readBmm150Trim() ||
+        !writeBmm150Reg(BMM150_REP_XY_ADDR, BMM150_REP_XY_REGULAR) ||
         !writeBmm150Reg(BMM150_REP_Z_ADDR, BMM150_REP_Z_REGULAR) ||
         !writeBmm150Reg(BMM150_OP_MODE_ADDR, BMM150_OP_MODE_FORCED) ||
         !setBmi160AuxReadAddr(BMM150_DATA_X_LSB_ADDR) ||
@@ -196,6 +239,7 @@ bool DFRobot_BMX160::setBmi160AuxMagnConf()
     }
 
     delay(50);
+    _bmm150Ready = true;
 
     return true;
 }
@@ -258,12 +302,105 @@ bool DFRobot_BMX160::writeBmm150Reg(uint8_t reg, uint8_t value)
 
 bool DFRobot_BMX160::readBmm150Reg(uint8_t reg, uint8_t *value)
 {
+    return readBmm150Regs(reg, value, 1);
+}
+
+bool DFRobot_BMX160::readBmm150Regs(uint8_t reg, uint8_t *values, uint8_t len)
+{
+    if (values == nullptr || len == 0 || len > 8) {
+        return false;
+    }
+
     if (!setBmi160AuxReadAddr(reg)) {
         return false;
     }
     delay(BMX160_MAGN_COM_DELAY);
 
-    return readReg(BMX160_MAG_DATA_ADDR, value, 1);
+    return readReg(BMX160_MAG_DATA_ADDR, values, len);
+}
+
+bool DFRobot_BMX160::readBmm150Trim()
+{
+    uint8_t x1_y1[2] = {0};
+    uint8_t z4_x2_y2[4] = {0};
+    uint8_t z2_z1_xyz1_z3[8] = {0};
+    uint8_t xy2_xy1[2] = {0};
+
+    if (!readBmm150Regs(BMM150_DIG_X1_ADDR, x1_y1, sizeof(x1_y1)) ||
+        !readBmm150Regs(BMM150_DIG_Z4_LSB_ADDR, z4_x2_y2, sizeof(z4_x2_y2)) ||
+        !readBmm150Regs(BMM150_DIG_Z2_LSB_ADDR, z2_z1_xyz1_z3, sizeof(z2_z1_xyz1_z3)) ||
+        !readBmm150Regs(BMM150_DIG_XY2_ADDR, xy2_xy1, sizeof(xy2_xy1))) {
+        return false;
+    }
+
+    bmm150Trim.x1 = static_cast<int8_t>(x1_y1[0]);
+    bmm150Trim.y1 = static_cast<int8_t>(x1_y1[1]);
+    bmm150Trim.z4 = static_cast<int16_t>((static_cast<uint16_t>(z4_x2_y2[1]) << 8) | z4_x2_y2[0]);
+    bmm150Trim.x2 = static_cast<int8_t>(z4_x2_y2[2]);
+    bmm150Trim.y2 = static_cast<int8_t>(z4_x2_y2[3]);
+    bmm150Trim.z2 = static_cast<int16_t>((static_cast<uint16_t>(z2_z1_xyz1_z3[1]) << 8) |
+                                        z2_z1_xyz1_z3[0]);
+    bmm150Trim.z1 = static_cast<uint16_t>((static_cast<uint16_t>(z2_z1_xyz1_z3[3]) << 8) |
+                                         z2_z1_xyz1_z3[2]);
+    bmm150Trim.xyz1 = static_cast<uint16_t>((static_cast<uint16_t>(z2_z1_xyz1_z3[5] & 0x7F) << 8) |
+                                           z2_z1_xyz1_z3[4]);
+    bmm150Trim.z3 = static_cast<int16_t>((static_cast<uint16_t>(z2_z1_xyz1_z3[7]) << 8) |
+                                        z2_z1_xyz1_z3[6]);
+    bmm150Trim.xy2 = static_cast<int8_t>(xy2_xy1[0]);
+    bmm150Trim.xy1 = xy2_xy1[1];
+
+    return bmm150Trim.xyz1 != 0 && bmm150Trim.z1 != 0 && bmm150Trim.z2 != 0;
+}
+
+float DFRobot_BMX160::compensateBmm150X(int16_t raw_x, uint16_t rhall) const
+{
+    if (raw_x == BMM150_OVERFLOW_ADCVAL_XY || rhall == 0 || bmm150Trim.xyz1 == 0) {
+        return 0.0f;
+    }
+
+    const float process0 = static_cast<float>(bmm150Trim.xyz1) * 16384.0f / rhall;
+    const float centered = process0 - 16384.0f;
+    const float process1 = static_cast<float>(bmm150Trim.xy2) *
+                           (centered * centered / 268435456.0f);
+    const float process2 = process1 + centered * static_cast<float>(bmm150Trim.xy1) / 16384.0f;
+    const float process3 = static_cast<float>(bmm150Trim.x2) + 160.0f;
+    const float process4 = raw_x * ((process2 + 256.0f) * process3);
+
+    return ((process4 / 8192.0f) + static_cast<float>(bmm150Trim.x1) * 8.0f) / 16.0f;
+}
+
+float DFRobot_BMX160::compensateBmm150Y(int16_t raw_y, uint16_t rhall) const
+{
+    if (raw_y == BMM150_OVERFLOW_ADCVAL_XY || rhall == 0 || bmm150Trim.xyz1 == 0) {
+        return 0.0f;
+    }
+
+    const float process0 = static_cast<float>(bmm150Trim.xyz1) * 16384.0f / rhall;
+    const float centered = process0 - 16384.0f;
+    const float process1 = static_cast<float>(bmm150Trim.xy2) *
+                           (centered * centered / 268435456.0f);
+    const float process2 = process1 + centered * static_cast<float>(bmm150Trim.xy1) / 16384.0f;
+    const float process3 = static_cast<float>(bmm150Trim.y2) + 160.0f;
+    const float process4 = raw_y * ((process2 + 256.0f) * process3);
+
+    return ((process4 / 8192.0f) + static_cast<float>(bmm150Trim.y1) * 8.0f) / 16.0f;
+}
+
+float DFRobot_BMX160::compensateBmm150Z(int16_t raw_z, uint16_t rhall) const
+{
+    if (raw_z == BMM150_OVERFLOW_ADCVAL_Z || bmm150Trim.z2 == 0 ||
+        bmm150Trim.z1 == 0 || bmm150Trim.xyz1 == 0 || rhall == 0) {
+        return 0.0f;
+    }
+
+    const float process0 = static_cast<float>(raw_z) - static_cast<float>(bmm150Trim.z4);
+    const float process1 = static_cast<float>(rhall) - static_cast<float>(bmm150Trim.xyz1);
+    const float process2 = static_cast<float>(bmm150Trim.z3) * process1;
+    const float process3 = static_cast<float>(bmm150Trim.z1) * static_cast<float>(rhall) / 32768.0f;
+    const float process4 = static_cast<float>(bmm150Trim.z2) + process3;
+    const float process5 = process0 * 131072.0f - process2;
+
+    return (process5 / (process4 * 4.0f)) / 16.0f;
 }
 
 void DFRobot_BMX160::setGyroRange(eGyroRange_t bits){
@@ -329,14 +466,45 @@ void DFRobot_BMX160::getAllData(sBmx160SensorData_t *magn, sBmx160SensorData_t *
     uint8_t data[23] = {0};
     int16_t x=0,y=0,z=0;
     // put your main code here, to run repeatedly:
-    readReg(BMX160_MAG_DATA_ADDR, data, 23);
+    if (!readReg(BMX160_MAG_DATA_ADDR, data, sizeof(data))) {
+        if (magn) *magn = {};
+        if (gyro) *gyro = {};
+        if (accel) *accel = {};
+        return;
+    }
     if(magn){
-        x = (int16_t) (((uint16_t)data[1] << 8) | data[0]);
-        y = (int16_t) (((uint16_t)data[3] << 8) | data[2]);
-        z = (int16_t) (((uint16_t)data[5] << 8) | data[4]);
-        magn->x = x * BMX160_MAGN_UT_LSB;
-        magn->y = y * BMX160_MAGN_UT_LSB;
-        magn->z = z * BMX160_MAGN_UT_LSB;
+        const int16_t raw_x = static_cast<int16_t>(static_cast<int16_t>(static_cast<int8_t>(data[1])) * 32 |
+                                                   ((data[0] & 0xF8) >> 3));
+        const int16_t raw_y = static_cast<int16_t>(static_cast<int16_t>(static_cast<int8_t>(data[3])) * 32 |
+                                                   ((data[2] & 0xF8) >> 3));
+        const int16_t raw_z = static_cast<int16_t>(static_cast<int16_t>(static_cast<int8_t>(data[5])) * 128 |
+                                                   ((data[4] & 0xFE) >> 1));
+        const uint16_t rhall = static_cast<uint16_t>((static_cast<uint16_t>(data[7]) << 6) |
+                                                     ((data[6] & 0xFC) >> 2));
+
+        if (_bmm150Ready) {
+            const float bmm_x = compensateBmm150X(raw_x, rhall);
+            const float bmm_y = compensateBmm150Y(raw_y, rhall);
+            const float bmm_z = compensateBmm150Z(raw_z, rhall);
+
+            if (_standaloneBmi160) {
+                /*
+                 * The new PCB placement keeps BMM150 +X aligned with BMI160 +X.
+                 * Y and Z point in the opposite direction, so rotate the magnetic
+                 * vector into the accelerometer/gyroscope coordinate frame.
+                 */
+                magn->x = bmm_x;
+                magn->y = -bmm_y;
+                magn->z = -bmm_z;
+            } else {
+                /* BMX160 internally aligns its BMM150 die with the IMU frame. */
+                magn->x = bmm_x;
+                magn->y = bmm_y;
+                magn->z = bmm_z;
+            }
+        } else {
+            *magn = {};
+        }
     }
     if(gyro){
         x = (int16_t) (((uint16_t)data[9] << 8) | data[8]);
@@ -388,12 +556,6 @@ bool DFRobot_BMX160::readReg(uint8_t reg, uint8_t *pBuf, uint16_t len)
 
 bool DFRobot_BMX160::scan()
 {
-   _i2c->aquire();
-
-   uint8_t dummy = 0;
-   int ret = i2c_write(_i2c->master, &dummy, 0, _addr);
-
-    _i2c->release();
-    
-   return (ret == 0);
+   uint8_t chip_id = 0;
+   return probeAddress(_addr, &chip_id);
 }

--- a/src/SensorManager/BMX160/DFRobot_BMX160.h
+++ b/src/SensorManager/BMX160/DFRobot_BMX160.h
@@ -254,6 +254,13 @@
 #define BMM150_OP_MODE_FORCED                    0x02
 #define BMM150_REP_XY_REGULAR                    0x04
 #define BMM150_REP_Z_REGULAR                     0x0E
+#define BMM150_DIG_X1_ADDR                       0x5D
+#define BMM150_DIG_Z4_LSB_ADDR                   0x62
+#define BMM150_DIG_Z2_LSB_ADDR                   0x68
+#define BMM150_DIG_XY2_ADDR                      0x70
+
+#define BMM150_OVERFLOW_ADCVAL_XY                (-4096)
+#define BMM150_OVERFLOW_ADCVAL_Z                 (-16384)
 
 /** Error code definitions */
 #define BMX160_OK                                0
@@ -276,6 +283,11 @@
 
 /** bmx160 unique chip identifier */
 #define BMX160_CHIP_ID                           0xD8
+#define BMI160_CHIP_ID                           0xD1
+
+/** I2C addresses selected by the SDO pin */
+#define BMI160_I2C_ADDR_SDO_LOW                  0x68
+#define BMI160_I2C_ADDR_SDO_HIGH                 0x69
 
 /** Soft reset command */
 #define BMX160_SOFT_RESET_CMD                    0xb6
@@ -1012,6 +1024,17 @@ class DFRobot_BMX160{
     bool begin();
 
     /**
+     * @brief Probe both BMI160/BMX160 I2C addresses and select the detected one.
+     *
+     * The original BMX160 board uses 0x68. Hardware revision 2.1 and newer
+     * uses a standalone BMI160 at 0x69.
+     */
+    bool detect();
+
+    /** @return true when the standalone BMI160 was detected at 0x69. */
+    bool isStandaloneBmi160() const;
+
+    /**
      * @fn setGyroRange
      * @brief set gyroscope angular rate range and resolution.
      * @param bits 
@@ -1133,11 +1156,33 @@ class DFRobot_BMX160{
     bool setBmi160AuxMode(bool manual, uint8_t read_burst_len);
     bool writeBmm150Reg(uint8_t reg, uint8_t value);
     bool readBmm150Reg(uint8_t reg, uint8_t *value);
+    bool readBmm150Regs(uint8_t reg, uint8_t *values, uint8_t len);
+    bool readBmm150Trim();
     bool setBmi160AuxReadAddr(uint8_t reg);
+    bool probeAddress(uint8_t addr, uint8_t *chip_id);
+    float compensateBmm150X(int16_t raw_x, uint16_t rhall) const;
+    float compensateBmm150Y(int16_t raw_y, uint16_t rhall) const;
+    float compensateBmm150Z(int16_t raw_z, uint16_t rhall) const;
+
+    struct Bmm150TrimData {
+      int8_t x1 = 0;
+      int8_t y1 = 0;
+      int8_t x2 = 0;
+      int8_t y2 = 0;
+      uint16_t z1 = 0;
+      int16_t z2 = 0;
+      int16_t z3 = 0;
+      int16_t z4 = 0;
+      uint8_t xy1 = 0;
+      int8_t xy2 = 0;
+      uint16_t xyz1 = 0;
+    } bmm150Trim;
 
     float accelRange = BMX160_ACCEL_MG_LSB_2G * EARTH_ACC;
     float gyroRange = BMX160_GYRO_SENSITIVITY_2000DPS;
     uint8_t _addr = DT_REG_ADDR(DT_NODELABEL(bmx160));
+    bool _standaloneBmi160 = false;
+    bool _bmm150Ready = false;
     
     sBmx160Dev_t* Obmx160;
 

--- a/src/SensorManager/IMU.cpp
+++ b/src/SensorManager/IMU.cpp
@@ -1,6 +1,7 @@
 #include "IMU.h"
 
 #include "SensorManager.h"
+#include "uicr.h"
 
 #include <zephyr/kernel.h>
 #include <zephyr/zbus/zbus.h>
@@ -23,6 +24,25 @@ const SampleRateSetting<6> IMU::sample_rates = {
 
 	{ 25.0, 50.0, 100.0, 200.0, 400.0, 800.0 }
 };
+
+void IMU::detectHardwareRevision()
+{
+	const int power_result = pm_device_runtime_get(ls_1_8);
+	if (power_result < 0) {
+		LOG_WRN("Could not power the IMU rail for hardware detection: %d", power_result);
+		return;
+	}
+
+	const bool detected = imu.detect();
+	if (detected && imu.isStandaloneBmi160()) {
+		const int revision_result = uicr_hw_revision_promote_2_0_to_2_1();
+		if (revision_result != 0) {
+			LOG_ERR("Could not promote detected hardware revision to 2.1: %d", revision_result);
+		}
+	}
+
+	pm_device_runtime_put(ls_1_8);
+}
 
 void IMU::update_sensor(struct k_work *work) {
 	int ret;

--- a/src/SensorManager/IMU.h
+++ b/src/SensorManager/IMU.h
@@ -13,6 +13,7 @@ public:
     bool init(struct k_msgq * queue) override;
     void start(int sample_rate_idx) override;
     void stop() override;
+    static void detectHardwareRevision();
 
     const static SampleRateSetting<6> sample_rates;
 private:

--- a/src/SensorManager/SensorManager.cpp
+++ b/src/SensorManager/SensorManager.cpp
@@ -85,6 +85,10 @@ void sensor_chan_update(void *p1, void *p2, void *p3) {
 	}
 }
 
+void detect_sensor_hardware_revision() {
+	IMU::detectHardwareRevision();
+}
+
 void init_sensor_manager() {
 	_state = INIT;
 

--- a/src/SensorManager/SensorManager.h
+++ b/src/SensorManager/SensorManager.h
@@ -21,6 +21,8 @@ extern struct k_work_q sensor_work_q;
 
 enum sensor_manager_state get_state();
 
+void detect_sensor_hardware_revision();
+
 void init_sensor_manager();
 
 void start_sensor_manager();

--- a/src/utils/uicr.c
+++ b/src/utils/uicr.c
@@ -22,6 +22,11 @@ LOG_MODULE_REGISTER(uicr, CONFIG_LOG_DEFAULT_LEVEL);
 #define MEM_ADDR_UICR_STAL (MEM_ADDR_UICR_SIRK + sizeof(uint32_t))
 #define MEM_ADDR_UICR_HW (MEM_ADDR_UICR_STAL + sizeof(uint32_t))
 
+#define HW_REVISION_BLANK 0xFFFFFFFFU
+#define HW_REVISION_2_1_0 0x02010000U
+
+static bool hw_revision_2_1_runtime_floor;
+
 uint8_t uicr_channel_get(void)
 {
 	return *(uint8_t *)MEM_ADDR_UICR_CH;
@@ -91,11 +96,54 @@ void uicr_hw_revision_get(char *hw_version)
 	uint8_t minor = (hw_data >> 16) & 0xFF;
 	uint8_t patch = (hw_data >> 8) & 0xFF;
 
-	if (major == 0xFF && minor == 0xFF && patch == 0xFF) {
+	if (hw_data == HW_REVISION_BLANK) {
 		LOG_WRN("UICR HW revision not set, returning default 2.0.0");
-		snprintf(hw_version, 16, "2.0.0");
-		return;
+		major = 2;
+		minor = 0;
+		patch = 0;
+	}
+
+	if (hw_revision_2_1_runtime_floor && major == 2 && minor == 0) {
+		minor = 1;
 	}
 
 	snprintf(hw_version, 16, "%u.%u.%u", major, minor, patch);
+}
+
+int uicr_hw_revision_promote_2_0_to_2_1(void)
+{
+	const uint32_t hw_data = *(uint32_t *)MEM_ADDR_UICR_HW;
+	uint8_t major = (hw_data >> 24) & 0xFF;
+	uint8_t minor = (hw_data >> 16) & 0xFF;
+
+	if (hw_data == HW_REVISION_BLANK) {
+		major = 2;
+		minor = 0;
+	}
+
+	if (major != 2 || minor != 0) {
+		return 0;
+	}
+
+	hw_revision_2_1_runtime_floor = true;
+
+	if (hw_data != HW_REVISION_BLANK) {
+		/* UICR writes can only clear bits; 2.0.x -> 2.1.x needs a page erase. */
+		LOG_WRN("Detected HW >=2.1; reporting 2.1.x without erasing programmed UICR");
+		return 0;
+	}
+
+	if (!nrfx_nvmc_word_writable_check(MEM_ADDR_UICR_HW, HW_REVISION_2_1_0)) {
+		return -EIO;
+	}
+
+	nrfx_nvmc_word_write(MEM_ADDR_UICR_HW, HW_REVISION_2_1_0);
+	while (!nrfx_nvmc_write_done_check()) {}
+
+	if (*(uint32_t *)MEM_ADDR_UICR_HW != HW_REVISION_2_1_0) {
+		return -EIO;
+	}
+
+	LOG_INF("Detected HW >=2.1; stored hardware revision 2.1.0 in UICR");
+	return 0;
 }

--- a/src/utils/uicr.h
+++ b/src/utils/uicr.h
@@ -63,6 +63,19 @@ uint64_t uicr_snr_get(void);
  */
 void uicr_hw_revision_get(char *hw_version);
 
+/**
+ * @brief Promote a 2.0.x hardware revision to 2.1.x.
+ *
+ * A blank UICR value is persisted as 2.1.0. An already-programmed 2.0.x
+ * value cannot be changed without erasing the full UICR page, so the
+ * promoted value is applied at runtime and reported through Device Info.
+ * The hardware probe repeats on every boot.
+ *
+ * @return 0 when no promotion is needed or the promoted value is active
+ * @return -EIO if a blank UICR value could not be programmed
+ */
+int uicr_hw_revision_promote_2_0_to_2_1(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/unicast_server/main.cpp
+++ b/unicast_server/main.cpp
@@ -64,6 +64,8 @@ int main(void) {
 	ret = power_manager.begin();
 	ERR_CHK(ret);
 
+	detect_sensor_hardware_revision();
+
 	uint8_t standalone = uicr_standalone_get();
 
 	LOG_INF("Standalone mode: %i", standalone);


### PR DESCRIPTION
## Summary

This adds sensor support for OpenEarable hardware revision 2.1.0, which replaces the integrated BMX160 with a standalone BMI160 and an external BMM150 magnetometer.

- Detect the standalone BMI160 at its alternate I2C address (`0x69`) during boot while retaining support for BMX160/BMI160 devices at `0x68`.
- Configure the external BMM150 through the BMI160 auxiliary I2C interface.
- Decode the packed BMM150 samples correctly and apply the sensor factory-trim compensation.
- Preserve the compensated BMM150 axis order consistently across hardware revisions; paired multi-pose measurements show that hardware 2.1 must not receive a separate Y/Z inversion.
- Automatically report detected 2.1 hardware as at least `2.1.x` when its stored revision is `2.0.x`.
- Persist `2.1.0` when the UICR hardware-revision field is blank; use a runtime revision floor for programmed `2.0.x` values because UICR cannot change those bits without erasing the page.

The changes are intentionally limited to IMU/magnetometer support and hardware-version detection; audio/ADAU behavior is unchanged. BMM150 factory compensation is distinct from unit-specific hard-/soft-iron calibration, so no prototype-specific magnetic offsets are hard-coded.

## Validation

- Full firmware build succeeds for `openearable_v2/nrf5340/cpuapp` with nRF Connect SDK 3.0.1.
- The original hardware-support revision was flashed successfully to the hardware 2.1.0 prototype through J-Link and boot-time detection selected the BMI160 at `0x69`.
- Captured eight stationary paired poses from a rigidly coupled hardware 2.0 BMX160 board and hardware 2.1 BMI160+BMM150 board, covering all six gravity directions plus yaw and a diagonal pose.
- Accelerometer comparison found no axis permutation or sign inversion; the fitted relative mounting angle was about 3.2 degrees.
- BMM150 factory-compensation output matches the Bosch-style reference calculation within 0.2 microtesla across the captured dataset, with stationary per-axis noise below about 1 microtesla.
- Paired magnetic changes show matching BMM150 axis direction between the two assemblies, invalidating the earlier hardware-2.1-only Y/Z inversion.